### PR TITLE
Fix issues relating to the MultiJumpTrinket

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
@@ -13,11 +13,14 @@ import iskallia.vault.entity.entity.elite.*;
 import iskallia.vault.gear.attribute.type.VaultGearAttributeTypeMerger;
 import iskallia.vault.gear.data.VaultGearData;
 import iskallia.vault.gear.item.VaultGearItem;
+import iskallia.vault.gear.trinket.TrinketHelper;
+import iskallia.vault.gear.trinket.effects.MultiJumpTrinket;
 import iskallia.vault.util.calc.PlayerStat;
 import iskallia.vault.world.data.ServerVaults;
 import net.minecraft.core.Registry;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.sounds.SoundEvent;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.damagesource.DamageSource;
@@ -27,6 +30,7 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
+import net.minecraftforge.event.entity.living.LivingFallEvent;
 import net.minecraftforge.event.entity.living.LivingHurtEvent;
 import net.minecraftforge.event.world.BlockEvent;
 import net.minecraftforge.eventbus.api.EventPriority;
@@ -188,6 +192,28 @@ public class LivingEntityEvents {
                             });
                         }
                     }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles the reduction/cancellation of fall damage for players with the Feather Trinket equipped.
+     * <p>
+     * If the player has an active and usable {@code MultiJumpTrinket}:
+     * - Fall damage is canceled if the fall distance is less than 5.0 blocks to prevent damage ticking when taking no damage.
+     * - Otherwise, the fall distance is reduced by 2.0 blocks to mitigate fall damage.
+     * <p>
+     * Called whenever a LivingEntity falls
+     */
+    @SubscribeEvent
+    public static void multiJumpTrinketFallReductionEvent(LivingFallEvent event) {
+        if(event.getEntityLiving() instanceof ServerPlayer player) {
+            if (!TrinketHelper.getTrinkets(player, MultiJumpTrinket.class).stream().noneMatch((trinket) -> trinket.isUsable(player))) {
+                if(event.getDistance() < 5.0F) {
+                    event.setCanceled(true);
+                } else {
+                    event.setDistance(event.getDistance() - 2.0F);
                 }
             }
         }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinMultiJumpTrinket.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinMultiJumpTrinket.java
@@ -1,0 +1,32 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.gear.trinket.effects.MultiJumpTrinket;
+import net.minecraft.world.entity.player.Player;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(value = MultiJumpTrinket.class, remap = false)
+public class MixinMultiJumpTrinket {
+    @Shadow private static boolean clientIsJumpHeld = false;
+
+    /**
+     * Fixes an issue present when holding the jump button and landing on the ground again,
+     * <p>
+     * If the player held the jump button as they land, they would not receive the additional velocity boost upwards,
+     * this mixin aims to resolve this.
+     */
+    @Inject(
+            method = "onClientTick",
+            at = @At(value = "FIELD",
+                    target = "Liskallia/vault/gear/trinket/effects/MultiJumpTrinket;clientJumpCount:I",
+                    ordinal = 0),
+            require = 1
+    )
+    private void afterResetJumpCount(Player player, CallbackInfo ci) {
+        clientIsJumpHeld = false;
+    }
+
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -122,6 +122,7 @@
     "vaulthunters.fixes.MixinLootableItem",
     "vaulthunters.fixes.MixinMixinWorldChunk",
     "vaulthunters.fixes.MixinMonolithRenderer",
+    "vaulthunters.fixes.MixinMultiJumpTrinket",
     "vaulthunters.fixes.MixinOfferingBossCrystalObjective",
     "vaulthunters.fixes.MixinOfferingBossTileEntity",
     "vaulthunters.fixes.MixinOfferingItem",


### PR DESCRIPTION
This PR resolves 2 issues regarding the MultiJumpTrinket
- Resolves issue with not gaining the additional velocity when holding the Jump button and landing on ground again
- Mimics the behaviour of the Jump boost effect with the additional velocity gain provided by the MultiJumpTrinket, reducing fall damage
- (untested)