### PR TITLE
only replace default inventory with starter gear

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ dependencies {
     implementation fg.deobf("curse.maven:occultism-361026:4729072")
     implementation fg.deobf("curse.maven:ars-nouveau-401955:4543053")
     implementation fg.deobf("curse.maven:open-parties-and-claims-636608:4982642")
+    implementation fg.deobf("curse.maven:custom-starter-gear-253735:4683370")
     //implementation fg.deobf("curse.maven:vault-hunters-api-1118899:5800243")
     compileOnly "curse.maven:citadel4-331936:3683009" // change to 3548061
     runtimeOnly "curse.maven:citadel4-331936:3683009"

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/customstartinggear/MixinDataManager.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/customstartinggear/MixinDataManager.java
@@ -1,0 +1,42 @@
+package xyz.iwolfking.woldsvaults.mixins.customstartinggear;
+
+import com.brandon3055.csg.DataManager;
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import net.minecraft.world.entity.player.Inventory;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Restriction(
+    require = {
+        @Condition(type = Condition.Type.MOD, value = "customstartinggear")
+    }
+)
+@Mixin(value = DataManager.class, remap = false)
+public class MixinDataManager {
+    @Redirect(method = "givePlayerStartGear", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/player/Inventory;clearContent()V", remap = true))
+    private static void onlyDeleteDefaultItems(Inventory inventory) {
+        Set<String> defaultItems = new HashSet<>();
+        defaultItems.add("patchouli:guide_book");
+        defaultItems.add("the_vault:quest_book");
+
+        boolean defaultInventory = true;
+        for (int i = 0; i < inventory.getContainerSize(); i++) {
+            var is = inventory.getItem(i);
+            if (!is.isEmpty()) {
+                var rl = is.getItem().getRegistryName();
+                if (rl == null || !defaultItems.contains(rl.toString())) {
+                    defaultInventory = false;
+                    break;
+                }
+            }
+        }
+        if (defaultInventory){
+            inventory.clearContent();
+        }
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -22,6 +22,7 @@
     "cloudstorage.MixinBalloonBuddyEntity",
     "cofhcore.MixinCofhEnchantment",
     "cookingforblockheads.MixinKitchenBlock",
+    "customstartinggear.MixinDataManager",
     "dimensional_worldborder.MixinDimensionalWorldborder",
     "dyenamicsandfriends.MixinComputerCraftCompatModule",
     "dyenamicsandfriends.MixinIncBootstrapForge",


### PR DESCRIPTION
After this pr csg will replace player's inventory only if it contains guide books or vh quest book

if player has anything else in their inventory when they load in for the first time the starter item will be either added to the corresponding slot or dropped on ground if it's not empty