### PR TITLE
Add Breaching & normalizedModifierEnabled config option

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/config/forge/WoldsVaultsConfig.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/config/forge/WoldsVaultsConfig.java
@@ -35,10 +35,12 @@ public class WoldsVaultsConfig
         //public final ForgeConfigSpec.ConfigValue<Boolean> disableVanillaUnsupportedElixirEvents;
 
         public final ForgeConfigSpec.ConfigValue<Boolean> disableFlightInVaults;
+        public final ForgeConfigSpec.ConfigValue<Boolean> normalizedModifierEnabled;
         public final ForgeConfigSpec.ConfigValue<Boolean> enableMoteRecipes;
         public final ForgeConfigSpec.ConfigValue<Boolean> displayItemBordersInTerminals;
         public final ForgeConfigSpec.ConfigValue<Boolean> enableDebugMode;
         public final ForgeConfigSpec.ConfigValue<Integer> crystalReinforcementMaxCapacityAdded;
+
         public Common(ForgeConfigSpec.Builder builder)
         {
             builder.push("Features");
@@ -54,6 +56,8 @@ public class WoldsVaultsConfig
             builder.push("Vault Settings");
             this.disableFlightInVaults= builder.comment("Controls whether Creative flight should be blocked while inside a vault. (default: true)")
                     .define("disableFlightInVaults", true);
+            this.normalizedModifierEnabled = builder.comment("Whether the \"Normalized\" Modifier should be enabled and functional (default: true)")
+                    .define("normalizedModifierEnabled", true);
             builder.pop();
             builder.push("Gameplay Settings");
             this.enableMoteRecipes= builder.comment("Controls whether Mote of Purity, Sanctity, and Clarity should work in the Crystal Workbench. (default: false)")

--- a/src/main/java/xyz/iwolfking/woldsvaults/init/ModGearAttributes.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/init/ModGearAttributes.java
@@ -47,6 +47,8 @@ public class ModGearAttributes {
 
     public static final VaultGearAttribute<Boolean> TREASURE_AFFINITY = attr("treasure_affinity", VaultGearAttributeType.booleanType(), ModGearAttributeGenerators.booleanFlag(), ModGearAttributeReaders.booleanReader("Treasure Affinity", 16749824), VaultGearAttributeComparator.booleanComparator());
 
+    public static final VaultGearAttribute<Boolean> BREACHING = attr("breaching", VaultGearAttributeType.booleanType(), ModGearAttributeGenerators.booleanFlag(), ModGearAttributeReaders.booleanReader("Breaching", 10031431), VaultGearAttributeComparator.booleanComparator());
+
     @SubscribeEvent
     public static void init(RegistryEvent.Register<VaultGearAttribute<?>> event) {
         IForgeRegistry<VaultGearAttribute<?>> registry = event.getRegistry();
@@ -65,6 +67,7 @@ public class ModGearAttributes {
         registry.register(EXECUTION_DAMAGE);
         registry.register(THORNS_SCALING_DAMAGE);
         registry.register(TREASURE_AFFINITY);
+        registry.register(BREACHING);
     }
 
     public static void registerVanillaAssociations() {

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/block/MixinCoinPileBlock.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/block/MixinCoinPileBlock.java
@@ -1,0 +1,65 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.block;
+
+import com.llamalad7.mixinextras.injector.WrapWithCondition;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import iskallia.vault.block.CoinPileBlock;
+import iskallia.vault.gear.data.VaultGearData;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.EntityBlock;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.material.FluidState;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import xyz.iwolfking.woldsvaults.init.ModGearAttributes;
+
+@Mixin(value = CoinPileBlock.class, remap = false)
+public abstract class MixinCoinPileBlock extends Block implements EntityBlock {
+    @Shadow
+    private void generateLoot(Level level, BlockPos pos, Player player) { }
+
+    // dummy constructor
+    public MixinCoinPileBlock(Properties pProperties) {
+        super(pProperties);
+    }
+
+    // We already overwrote the one in VaultChestBlock, so we might as well commit.
+    /**
+     * @author a1qs
+     * @reason add Breaching as a consideration
+     */
+    @Overwrite
+    public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
+        CoinPileBlock thisInstance = ((CoinPileBlock) (Object) this);
+        int size = state.getValue(CoinPileBlock.SIZE);
+        if (!player.isCreative()) {
+            thisInstance.playerWillDestroy(level, pos, state, player);
+
+            VaultGearData data = VaultGearData.read(player.getMainHandItem().copy());
+            boolean hasBreach = data.hasAttribute(ModGearAttributes.BREACHING);
+
+            if(hasBreach) {
+                for (int currentSize = size; currentSize > 0; currentSize--) {
+                    generateLoot(level, pos, player);
+                }
+                level.setBlock(pos, fluid.createLegacyBlock(), level.isClientSide ? 11 : 3);
+
+            } else {
+                generateLoot(level, pos, player);
+                if (size != 1) {
+                    level.setBlock(pos, state.setValue(CoinPileBlock.SIZE, size - 1), level.isClientSide ? 11 : 3);
+                } else {
+                    level.setBlock(pos, fluid.createLegacyBlock(), level.isClientSide ? 11 : 3);
+                }
+            }
+
+            return true;
+        } else {
+            return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/block/MixinVaultChestBlock.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/block/MixinVaultChestBlock.java
@@ -12,12 +12,12 @@ import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.Blocks;
 import net.minecraft.world.level.block.ChestBlock;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.entity.ChestBlockEntity;
 import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.gameevent.GameEvent;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import xyz.iwolfking.woldsvaults.init.ModGearAttributes;
@@ -39,42 +39,56 @@ public class MixinVaultChestBlock extends ChestBlock {
      */
     @Overwrite
     public void playerDestroy(Level world, Player player, BlockPos pos, BlockState state, @Nullable BlockEntity te, ItemStack stack) {
-        if (!((VaultChestBlock) (Object) this).hasStepBreaking()) {
+        VaultChestBlock thisInstance = ((VaultChestBlock) (Object) this);
+        if (!thisInstance.hasStepBreaking()) {
             super.playerDestroy(world, player, pos, state, te, stack);
         } else {
-            player.awardStat(Stats.BLOCK_MINED.get((VaultChestBlock) (Object) this));
+            player.awardStat(Stats.BLOCK_MINED.get(thisInstance));
             player.causeFoodExhaustion(0.005F);
-            if (te instanceof VaultChestTileEntity) {
-                VaultChestTileEntity chest = (VaultChestTileEntity)te;
+            if (te instanceof VaultChestTileEntity chest) {
                 VaultGearData data = VaultGearData.read(player.getMainHandItem().copy());
+                if(data == null) return;
+
+                boolean hasBreach = data.hasAttribute(ModGearAttributes.BREACHING);
                 float dismantle_chance = 0.0F;
-                if(data != null && data.hasAttribute(ModGearAttributes.DISMANTLE_CHANCE)) {
+
+                if(data.hasAttribute(ModGearAttributes.DISMANTLE_CHANCE)) {
                     dismantle_chance = data.get(ModGearAttributes.DISMANTLE_CHANCE, VaultGearAttributeTypeMerger.floatSum());
                 }
+
                 for(int slot = 0; slot < chest.getContainerSize(); ++slot) {
                     ItemStack invStack = chest.getItem(slot);
                     if (!invStack.isEmpty()) {
                         Block.popResource(world, pos, invStack);
                         chest.setItem(slot, ItemStack.EMPTY);
-                        if (dismantle_chance >= 1.0F) {
-                            dismantle_chance -= 1.0F;
-                            this.spawnDestroyParticles(world, player, pos, state);
-                        } else if (dismantle_chance > 0.0F) {
-                            if (dismantle_chance < Math.random()) {
+
+                        if(!hasBreach) {
+                            if (dismantle_chance >= 1.0F) {
+                                dismantle_chance -= 1.0F;
+                                this.spawnDestroyParticles(world, player, pos, state);
+                            } else if (dismantle_chance > 0.0F) {
+                                if (dismantle_chance < Math.random()) {
+                                    break;
+                                }
+                                this.spawnDestroyParticles(world, player, pos, state);
+                                dismantle_chance = 0.0F;
+                            } else {
                                 break;
                             }
-                            this.spawnDestroyParticles(world, player, pos, state);
-                            dismantle_chance = 0.0F;
-                        } else {
-                            break;
                         }
                     }
                 }
+
+                if(hasBreach) {
+                    world.setBlock(pos, Blocks.AIR.defaultBlockState(), Block.UPDATE_ALL);
+                }
+
             }
         }
     }
     /*@Inject(method = "playerDestroy", at = @At(value = "INVOKE", target = "Liskallia/vault/block/entity/VaultChestTileEntity;setItem(ILnet/minecraft/world/item/ItemStack;)V"))
     private void calculateDismantle(CallbackInfo info) {
         System.out.println("A1 I'm not doing this");
+        WoldsVaults.LOGGER.info("pengo nooo, why would you do this to me");
     }*/
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/modifiers/vault/DifficultyLockModifier.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/modifiers/vault/DifficultyLockModifier.java
@@ -13,6 +13,7 @@ import iskallia.vault.world.VaultDifficulty;
 import iskallia.vault.world.data.WorldSettings;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.eventbus.api.EventPriority;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.mixins.vaulthunters.accessors.VaultDifficultyAccessor;
 
 import java.util.HashMap;
@@ -29,52 +30,55 @@ public class DifficultyLockModifier extends VaultModifier<DifficultyLockModifier
 
     @Override
     public void initServer(VirtualWorld world, Vault vault, ModifierContext context) {
-        CommonEvents.PLAYER_TICK.register(context.getUUID(), EventPriority.HIGHEST, (event) -> {
-            if(event.side.isServer()) {
-                if((event.player.tickCount % 20) != 0) {
-                    return;
-                }
+        if(WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
+            CommonEvents.PLAYER_TICK.register(context.getUUID(), EventPriority.HIGHEST, (event) -> {
+                if(event.side.isServer()) {
+                    if((event.player.tickCount % 20) != 0) {
+                        return;
+                    }
 
-                if(!(event.player.getLevel().dimension().equals(world.dimension()))) {
-                    return;
-                }
+                    if(!(event.player.getLevel().dimension().equals(world.dimension()))) {
+                        return;
+                    }
 
-                if(vault.get(Vault.CLOCK).has(TickClock.PAUSED)) {
-                    return;
-                }
+                    if(vault.get(Vault.CLOCK).has(TickClock.PAUSED)) {
+                        return;
+                    }
 
-                if(event.player.getUUID() != vault.get(Vault.OWNER)) {
-                    return;
-                }
-                if(WorldSettings.get(world).getPlayerDifficulty(vault.get(Vault.OWNER)).equals(properties.getDifficulty())) {
-                    return;
-                }
+                    if(event.player.getUUID() != vault.get(Vault.OWNER)) {
+                        return;
+                    }
+                    if(WorldSettings.get(world).getPlayerDifficulty(vault.get(Vault.OWNER)).equals(properties.getDifficulty())) {
+                        return;
+                    }
 
-                if(!properties().shouldLockHigher() && isDifficultyHigher(world, vault)) {
-                    return;
+                    if(!properties().shouldLockHigher() && isDifficultyHigher(world, vault)) {
+                        return;
+                    }
+                    RETURN_DIFFICULTY_MAP.put(vault.get(Vault.OWNER), WorldSettings.get(world).getPlayerDifficulty(vault.get(Vault.OWNER)));
+                    WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), properties.getDifficulty());
                 }
-                RETURN_DIFFICULTY_MAP.put(vault.get(Vault.OWNER), WorldSettings.get(world).getPlayerDifficulty(vault.get(Vault.OWNER)));
-                WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), properties.getDifficulty());
-            }
-        });
+            });
+        }
     }
 
     @Override
     public void onListenerRemove(VirtualWorld world, Vault vault, ModifierContext context, Listener listener) {
-        vault.ifPresent(Vault.OWNER, owner -> {
-            if(listener.getPlayer().isPresent()) {
-                if(listener.getPlayer().get().getUUID().equals(owner)) {
-                    if(RETURN_DIFFICULTY_MAP.containsKey(vault.get(Vault.OWNER))) {
-                        WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), RETURN_DIFFICULTY_MAP.get(vault.get(Vault.OWNER)));
-                        return;
+        if(WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
+            vault.ifPresent(Vault.OWNER, owner -> {
+                if(listener.getPlayer().isPresent()) {
+                    if(listener.getPlayer().get().getUUID().equals(owner)) {
+                        if(RETURN_DIFFICULTY_MAP.containsKey(vault.get(Vault.OWNER))) {
+                            WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), RETURN_DIFFICULTY_MAP.get(vault.get(Vault.OWNER)));
+                            return;
+                        }
+
+                        WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), VaultDifficulty.NORMAL);
+                        RETURN_DIFFICULTY_MAP.clear();
                     }
-
-                    WorldSettings.get(world).setPlayerDifficulty(vault.get(Vault.OWNER), VaultDifficulty.NORMAL);
-                    RETURN_DIFFICULTY_MAP.clear();
                 }
-            }
-        });
-
+            });
+        }
     }
 
     private boolean isDifficultyHigher(VirtualWorld world, Vault vault) {

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/BallisticBingoObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/BallisticBingoObjective.java
@@ -37,6 +37,7 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.world.entity.player.Player;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.util.VaultModifierUtils;
 
 import java.util.Iterator;
@@ -97,7 +98,7 @@ public class BallisticBingoObjective extends BingoObjective {
             }
         }
 
-        if(!hasGeneratedModifiers) {
+        if(!hasGeneratedModifiers && WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
             VaultModifierUtils.addModifier(vault, VaultMod.id("normalized"), 1);
         }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesObjective.java
@@ -35,6 +35,7 @@ import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.phys.AABB;
 import net.minecraftforge.fml.loading.LoadingModList;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.init.ModItems;
 import xyz.iwolfking.woldsvaults.objectives.data.BrutalBossesRegistry;
 import xyz.iwolfking.woldsvaults.objectives.data.bosses.WoldBoss;
@@ -76,7 +77,7 @@ public class BrutalBossesObjective extends ObeliskObjective {
             }
         }
 
-        if(!hasGeneratedModifiers) {
+        if(!hasGeneratedModifiers && WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
             VaultModifierUtils.addModifier(vault, VaultMod.id("normalized"), 1);
         }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/EnchantedElixirObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/EnchantedElixirObjective.java
@@ -16,6 +16,7 @@ import iskallia.vault.core.world.storage.VirtualWorld;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.TextComponent;
 import net.minecraft.server.level.ServerPlayer;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.init.ModConfigs;
 import xyz.iwolfking.woldsvaults.objectives.data.EnchantedEventsRegistry;
 import xyz.iwolfking.woldsvaults.util.VaultModifierUtils;
@@ -52,7 +53,7 @@ public class EnchantedElixirObjective extends ElixirObjective {
             }
         }
 
-        if(!hasGeneratedModifiers) {
+        if(!hasGeneratedModifiers && WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
             VaultModifierUtils.addModifier(vault, VaultMod.id("normalized"), 1);
         }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/HauntedBraziersObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/HauntedBraziersObjective.java
@@ -67,6 +67,7 @@ import net.minecraftforge.api.distmarker.OnlyIn;
 import net.minecraftforge.fml.loading.LoadingModList;
 import net.minecraftforge.network.PacketDistributor;
 import vazkii.quark.content.mobs.entity.Wraith;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.util.VaultModifierUtils;
 
 import java.util.ArrayList;
@@ -110,7 +111,7 @@ public class HauntedBraziersObjective extends MonolithObjective {
             }
         }
 
-        if(!hasGeneratedModifiers) {
+        if(!hasGeneratedModifiers && WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
             VaultModifierUtils.addModifier(vault, VaultMod.id("normalized"), 1);
         }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/UnhingedScavengerObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/UnhingedScavengerObjective.java
@@ -34,6 +34,7 @@ import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraftforge.fml.loading.LoadingModList;
 import xyz.iwolfking.woldsvaults.config.UnhingedScavengerConfig;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
 import xyz.iwolfking.woldsvaults.util.VaultModifierUtils;
 
 import java.util.List;
@@ -73,7 +74,7 @@ public class UnhingedScavengerObjective extends ScavengerObjective {
             }
         }
 
-        if(!hasGeneratedModifiers) {
+        if(!hasGeneratedModifiers && WoldsVaultsConfig.COMMON.normalizedModifierEnabled.get()) {
             VaultModifierUtils.addModifier(vault, VaultMod.id("normalized"), 1);
         }
 

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -81,6 +81,7 @@
     "vaulthunters.altar.MixinVaultAltarIngredientsConfig",
     "vaulthunters.altar.MixinVaultAltarTileEntity",
     "vaulthunters.altar.VaultAltarTileEntityAccessor",
+    "vaulthunters.block.MixinCoinPileBlock",
     "vaulthunters.block.MixinVaultChestBlock",
     "vaulthunters.compat.angelring.MixinAngelBlock",
     "vaulthunters.compat.ensorcellation.MixinEnchanterEnchantSelectorModel",


### PR DESCRIPTION
This PR adds the ModGearAttribute `BREACHING` which allows for any chest to be instamined, as well as Coin piles.
In addition to this, it adds a new Config option in the WoldsVaults common config to disable the NormalizedModifier from applying in vaults, alongside its functionality not being applied if its set to false. By default its turned on.
