### PR TITLE
feat: Disable wandering wisp spawning from hexal via config toggle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -240,6 +240,7 @@ dependencies {
     implementation fg.deobf("curse.maven:grimoire-of-gaia-228948:5678608")
     implementation fg.deobf("curse.maven:tropicraft-254794:4616839")
     implementation fg.deobf("curse.maven:vault-hunters-api-1118899:6036598")
+    implementation fg.deobf("curse.maven:hexal-824725:5099219")
     implementation fg.deobf("curse.maven:occultism-361026:4729072")
     implementation fg.deobf("curse.maven:ars-nouveau-401955:4543053")
     implementation fg.deobf("curse.maven:custom-starter-gear-253735:4683370")

--- a/src/main/java/xyz/iwolfking/woldsvaults/config/forge/WoldsVaultsConfig.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/config/forge/WoldsVaultsConfig.java
@@ -40,7 +40,7 @@ public class WoldsVaultsConfig
         public final ForgeConfigSpec.ConfigValue<Boolean> displayItemBordersInTerminals;
         public final ForgeConfigSpec.ConfigValue<Boolean> enableDebugMode;
         public final ForgeConfigSpec.ConfigValue<Integer> crystalReinforcementMaxCapacityAdded;
-
+        public final ForgeConfigSpec.ConfigValue<Boolean> disableWanderingWispSpawning;
         public Common(ForgeConfigSpec.Builder builder)
         {
             builder.push("Features");
@@ -63,6 +63,8 @@ public class WoldsVaultsConfig
             this.enableMoteRecipes= builder.comment("Controls whether Mote of Purity, Sanctity, and Clarity should work in the Crystal Workbench. (default: false)")
                     .define("enableMoteRecipes", false);
             this.crystalReinforcementMaxCapacityAdded = builder.comment("The max capacity that can be added to a tool with Crystal Reinforcements. (default: 20)").define("crystalReinforcementMaxCapacityAdded", 20);
+            this.disableWanderingWispSpawning = builder.comment("Controls whether or not wandering wisps should spawn (default: true)")
+                    .define("disableWanderingWispSpawning", true);
             builder.pop();
             builder.push("Compatability Settings");
             builder.push("Item Borders");

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/hexal/MixinBlockEntitySlipway.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/hexal/MixinBlockEntitySlipway.java
@@ -1,0 +1,18 @@
+package xyz.iwolfking.woldsvaults.mixins.hexal;
+
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import ram.talia.hexal.common.blocks.entity.BlockEntitySlipway;
+import org.spongepowered.asm.mixin.Mixin;
+import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
+
+@Mixin(value = BlockEntitySlipway.class, remap = false)
+public class MixinBlockEntitySlipway {
+    @Inject(method = "serverTick", cancellable = true, at = @At(value="HEAD"))
+    private void serverTick(CallbackInfo ci) {
+        if (WoldsVaultsConfig.COMMON.disableWanderingWispSpawning.get()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -65,6 +65,7 @@
     "vaultarhud.MixinInventoryHudRender",
     "vaultarhud.MixinScreenValidator",
     "vaultfaster.fixes.MixinTemplateProcessorModifier",
+    "hexal.MixinBlockEntitySlipway",
     "vaulthunters.MixinModConfigs",
     "vaulthunters.accessors.ClassicCircleCrystalLayoutAccessor",
     "vaulthunters.accessors.ClassicInfiniteCrystalLayoutAccessor",


### PR DESCRIPTION
This PR as the title suggests adds the ability to disable the spawning of hexals wandering wisps via a config variable `disableWanderingWispSpawning`. It disables the spawning via cancelling the serverTick method on the Slipway block entity