### PR TITLE
Sort wold gear items

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/init/ModCustomVaultGearEntries.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/init/ModCustomVaultGearEntries.java
@@ -5,6 +5,7 @@ import net.minecraftforge.event.RegistryEvent;
 import xyz.iwolfking.vhapi.api.registry.gear.CustomVaultGearRegistryEntry;
 import xyz.iwolfking.woldsvaults.config.fake.CustomVaultGearModelRollRaritiesConfig;
 import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
+import xyz.iwolfking.woldsvaults.integration.jewelsorting.SortableVaultItems;
 import xyz.iwolfking.woldsvaults.models.*;
 
 public class ModCustomVaultGearEntries {
@@ -32,6 +33,8 @@ public class ModCustomVaultGearEntries {
         }
 
         event.getRegistry().register(RANG);
+
+        SortableVaultItems.addGear(ModItems.BATTLESTAFF, ModItems.TRIDENT, ModItems.PLUSHIE, ModItems.LOOT_SACK, ModItems.RANG);
 
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/integration/jewelsorting/SortableVaultItems.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/integration/jewelsorting/SortableVaultItems.java
@@ -1,0 +1,34 @@
+package xyz.iwolfking.woldsvaults.integration.jewelsorting;
+
+import iskallia.vault.gear.item.VaultGearItem;
+import net.minecraft.resources.ResourceLocation;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.util.Set;
+
+public class SortableVaultItems {
+
+    /**
+     * Add VaultGearItems to the Jewel Sorting mod's gear set.
+     * Only for items that require no special handling.
+     * It sorts by name, rarity, state, level, transmog and doesn't consider gear attributes.
+     */
+
+    @SuppressWarnings("unchecked")
+    public static void addGear(VaultGearItem... items) {
+        try { // avoid comptime dependency - bonne has disabled 3rd party sharing
+            Class<?> sortingHelper = Class.forName("lv.id.bonne.vaulthunters.jewelsorting.utils.SortingHelper");
+            VarHandle gearSetHandle = MethodHandles.publicLookup().findStaticVarHandle(sortingHelper, "VAULT_GEAR_SET", Set.class);
+            Set<ResourceLocation> gearSet = (Set<ResourceLocation>) gearSetHandle.get();
+            if (gearSet == null) {
+                return;
+            }
+            for (VaultGearItem item : items) {
+                gearSet.add(item.getItem().getRegistryName());
+            }
+        } catch (ClassNotFoundException | NoSuchFieldException | IllegalAccessException ignored) {
+            // jewel sorting not present or the class was changed - gear won't be sorted
+        }
+    }
+}


### PR DESCRIPTION
Adds wold gear items to jewelsorting gear set
I've added it next to gear registering, so it should be easy to update when adding new items
Uses reflection to avoid compile time dependency, which would require us having the jar in this repo because jewelsorting is not on cursemaven.