### PR TITLE
Flexible ability casting framework.

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleAbility.java
@@ -1,0 +1,79 @@
+/*
+* Lets you cast the specified ability around any entity
+* currently implemented:
+*   Nova
+*   Smite
+*   Implode
+* */
+
+package xyz.iwolfking.woldsvaults.abilities.flexible;
+
+import iskallia.vault.skill.ability.effect.ImplodeAbility;
+import iskallia.vault.skill.ability.effect.SmiteAbility;
+import iskallia.vault.skill.ability.effect.spi.AbstractNovaAbility;
+import iskallia.vault.skill.ability.effect.spi.core.Ability;
+import iskallia.vault.skill.base.Skill;
+import iskallia.vault.skill.base.SpecializedSkill;
+import iskallia.vault.skill.base.TieredSkill;
+import iskallia.vault.skill.tree.AbilityTree;
+import iskallia.vault.world.data.PlayerAbilitiesData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.jline.utils.Log;
+
+import java.util.Optional;
+
+public class FlexibleAbility {
+
+    public float cast(String ability, Player player, Entity target) {
+        Optional<Ability> abilityToCast = getAbilityData(ability, PlayerAbilitiesData.get((ServerLevel)player.level).getAbilities(player));
+        return abilityToCast.map(value -> castAbility(ability, value, player, target)).orElse(0F);
+    }
+
+    protected float castAbility(String ability, Ability abilityToCast, Player player, Entity target) {
+        float durabilityDamage = 0;
+        Log.info("Ability: " + abilityToCast);
+        switch (ability) {
+            case "Nova":
+                FlexibleNova novaAbility = new FlexibleNova();
+                novaAbility.cast(player, target, (AbstractNovaAbility) abilityToCast);
+                durabilityDamage = ((AbstractNovaAbility) abilityToCast).getManaCost();
+                break;
+            case "Implode":
+                FlexibleImplode implodeAbility = new FlexibleImplode();
+                if (target instanceof LivingEntity) {
+                    durabilityDamage = implodeAbility.cast(player, (LivingEntity) target, (ImplodeAbility) abilityToCast);
+                }
+                break;
+            case "Smite":
+                FlexibleSmite smiteAbility = new FlexibleSmite();
+                durabilityDamage = smiteAbility.cast(player, target, (SmiteAbility) abilityToCast);
+                break;
+            default:
+        }
+        return durabilityDamage;
+    }
+
+    public Optional<Ability> getAbilityData(String ability, AbilityTree tree) {
+        return tree.getForId(ability).map((skill) -> {
+            Object activeSkill;
+            if (skill instanceof SpecializedSkill specialized) {
+                activeSkill = specialized.getSpecialization();
+            } else {
+                activeSkill = skill;
+            }
+
+            Skill var2 = (Skill) activeSkill;
+            if (var2 instanceof TieredSkill tiered) {
+                activeSkill = tiered.getChild();
+            } else {
+                activeSkill = var2;
+            }
+
+            var2 = (Skill) activeSkill;
+            return (Ability) (var2 instanceof Ability ? var2 : null);
+        });
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleImplode.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleImplode.java
@@ -1,0 +1,46 @@
+package xyz.iwolfking.woldsvaults.abilities.flexible;
+
+import com.mojang.math.Vector3f;
+import iskallia.vault.client.particles.SphericalParticleOptions;
+import iskallia.vault.entity.entity.EternalEntity;
+import iskallia.vault.event.ActiveFlags;
+import iskallia.vault.init.ModParticles;
+import iskallia.vault.init.ModSounds;
+import iskallia.vault.skill.ability.effect.ImplodeAbility;
+import iskallia.vault.util.AABBHelper;
+import net.minecraft.core.particles.ParticleType;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.phys.Vec3;
+import org.jline.utils.Log;
+
+import java.util.List;
+
+public class FlexibleImplode extends ImplodeAbility {
+
+    public float cast(Player player, LivingEntity target, ImplodeAbility ability) {
+        Vec3 pos = target.position();
+        float health = target.getHealth();
+        float radius = ability.getRadius(player);
+        List<LivingEntity> targetEntities = player.level.getNearbyEntities(LivingEntity.class, TargetingConditions.forCombat().range((double)radius).selector((entity) -> !(entity instanceof Player) && !(entity instanceof EternalEntity)), player, AABBHelper.create(pos, radius));;
+        DamageSource damageSource = DamageSource.playerAttack(player);
+
+        for (LivingEntity entity : targetEntities) {
+            if (!entity.isInvulnerableTo(damageSource)) {
+                float damageModifier = this.getDamageModifier(ability.getRadius(target), target.distanceTo(entity));
+                float damage = health * ability.getPercentManaDealt() * damageModifier;
+                Log.info("Imploding " + entity + " with " + damage + " damage");
+                ActiveFlags.IS_AOE_ATTACKING.runIfNotSet(() -> entity.hurt(damageSource, damage));
+            }
+        }
+        ((ServerPlayer) player).getLevel().sendParticles(new SphericalParticleOptions((ParticleType) ModParticles.IMPLODE.get(), ability.getRadius(player), new Vector3f(0.0F, 1.0F, 1.0F)), target.getX(), target.getY(), target.getZ(), 400, (double) 0.0F, (double) 0.0F, (double) 0.0F, (double) 0.0F);
+        player.level.playSound((Player) null, target.getX(), target.getY(), target.getZ(), ModSounds.MANA_SHIELD, SoundSource.PLAYERS, 0.2F, 0.2F);
+        player.playNotifySound(ModSounds.MANA_SHIELD, SoundSource.PLAYERS, 0.2F, 0.2F);
+
+        return targetEntities.size();
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleNova.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleNova.java
@@ -1,0 +1,16 @@
+package xyz.iwolfking.woldsvaults.abilities.flexible;
+
+import iskallia.vault.mana.FullManaPlayer;
+import iskallia.vault.skill.ability.effect.NovaAbility;
+import iskallia.vault.skill.ability.effect.spi.AbstractNovaAbility;
+import iskallia.vault.skill.base.SkillContext;
+import iskallia.vault.skill.source.SkillSource;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.player.Player;
+
+public class FlexibleNova extends NovaAbility {
+    public void cast(Player player, Entity target, AbstractNovaAbility ability) {
+        ability.onAction(SkillContext.of((ServerPlayer) player, SkillSource.of(player).setPos(target.position()).setMana(FullManaPlayer.INSTANCE)));
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleSmite.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/flexible/FlexibleSmite.java
@@ -1,0 +1,38 @@
+package xyz.iwolfking.woldsvaults.abilities.flexible;
+
+import iskallia.vault.event.ActiveFlags;
+import iskallia.vault.init.ModSounds;
+import iskallia.vault.skill.ability.effect.SmiteAbility;
+import iskallia.vault.util.calc.AbilityPowerHelper;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.util.Mth;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+import org.jline.utils.Log;
+
+public class FlexibleSmite extends SmiteAbility {
+    public float cast(Player player, Entity target, SmiteAbility ability) {
+        DamageSource srcPlayerAttack = DamageSource.playerAttack(player);
+        SmiteBolt smiteBolt = iskallia.vault.init.ModEntities.SMITE_ABILITY_BOLT.create(player.level);
+        if (smiteBolt != null) {
+            smiteBolt.setColor(ability.getColor());
+            smiteBolt.moveTo(target.position());
+            player.level.addFreshEntity(smiteBolt);
+        }
+
+        ActiveFlags.IS_AP_ATTACKING.runIfNotSet(() -> ability.getFlag().runIfNotSet(() -> {
+            double damage = (double)(AbilityPowerHelper.getAbilityPower(player) * ability.getAbilityPowerPercent());
+            target.hurt(srcPlayerAttack, (float)damage);
+            Log.info("Smite Damage: " + damage);
+        }));
+        if (this.getFlag() == ActiveFlags.IS_SMITE_BASE_ATTACKING) {
+            player.level.playSound((Player)null, target.getX(), target.getY(), target.getZ(), ModSounds.SMITE_BOLT, SoundSource.PLAYERS, 1.0F, 1.0F + Mth.randomBetween(((LivingEntity) target).getRandom(), -0.2F, 0.2F));
+        } else {
+            player.level.playSound((Player)null, target.getX(), target.getY(), target.getZ(), ModSounds.SMITE_BOLT, SoundSource.PLAYERS, 0.7F, 1.5F + Mth.randomBetween(((LivingEntity) target).getRandom(), -0.2F, 0.2F));
+        }
+
+        return ability.getAdditionalManaPerBolt();
+    }
+}


### PR DESCRIPTION
This is the framework for allowing abilities to be easily cast around entities as targets. Currently, supports all variations of Nova, Implode, and Smite. To add more, add the ability into the switch in the flexibleAbiltiy class, and make a flexible[Ability name] file for the logic. This will later hopefully be implemented to make vault rangs cast abilities on hit.