### PR TITLE
don't force enable/disable xaero

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -276,6 +276,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
 
     implementation fg.deobf("curse.maven:inventory-hud-forge-357540:5639943")
+    compileOnly fg.deobf("curse.maven:xaeros-minimap-263420:3778436")
 
 
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinIntegrationMinimap.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinIntegrationMinimap.java
@@ -1,0 +1,38 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.integration.IntegrationMinimap;
+import me.fallenbreath.conditionalmixin.api.annotation.Condition;
+import me.fallenbreath.conditionalmixin.api.annotation.Restriction;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.Slice;
+import xaero.common.settings.ModOptions;
+import xaero.common.settings.ModSettings;
+
+@Restriction(
+    require = {
+        @Condition(type = Condition.Type.MOD, value = "xaerominimap")
+    }
+)
+@Mixin(value = IntegrationMinimap.class, remap = false)
+public class MixinIntegrationMinimap { // fix not being able to disable minimap outside of vaults
+
+    @Redirect(method = "lambda$onClientTick$0", at = @At(value = "INVOKE", target = "Lxaero/common/settings/ModSettings;getOptionValue(Lxaero/common/settings/ModOptions;)Ljava/lang/Object;", ordinal = 0),
+    slice = @Slice(
+            from = @At(value = "FIELD", target = "Lxaero/common/settings/ModOptions;MINIMAP:Lxaero/common/settings/ModOptions;"),
+            to = @At(value = "FIELD", target = "Lxaero/common/settings/ModOptions;SIZE:Lxaero/common/settings/ModOptions;")
+        )
+    )
+    private static Object dontDisableMinimapInVault(ModSettings instance, ModOptions par1EnumOptions) {
+        return false;
+    }
+
+    @Redirect(method = "lambda$onClientTick$0", at = @At(value = "INVOKE", target = "Lxaero/common/settings/ModSettings;getOptionValue(Lxaero/common/settings/ModOptions;)Ljava/lang/Object;", ordinal = 1),
+        slice = @Slice(
+            from = @At(value = "FIELD", target = "Lxaero/common/settings/ModOptions;SIZE:Lxaero/common/settings/ModOptions;")
+        ))
+    private static Object dontEnableMinimapInOverworld(ModSettings instance, ModOptions par1EnumOptions) {
+        return true;
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearRarity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearRarity.java
@@ -11,12 +11,12 @@ import org.spongepowered.asm.mixin.Shadow;
 
 @Mixin(value = VaultGearRarity.class, remap = false)
 public class MixinVaultGearRarity {
-    @Shadow @Final public static VaultGearRarity SCRAPPY;
-    @Shadow @Final public static VaultGearRarity COMMON;
-    @Shadow @Final public static VaultGearRarity RARE;
-    @Shadow @Final public static VaultGearRarity EPIC;
-    @Shadow @Final public static VaultGearRarity OMEGA;
-    @Shadow @Final public static VaultGearRarity UNIQUE;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity SCRAPPY;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity COMMON;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity RARE;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity EPIC;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity OMEGA;
+    @Shadow @Final @SuppressWarnings("target") public static VaultGearRarity UNIQUE;
     @Shadow @Final private TextColor color;
 
     /**

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -251,6 +251,7 @@
     "vaulthunters.custom.MixinVaultGearRarityColor",
     "vaulthunters.fixes.MixinCatalystItemRenderer",
     "vaulthunters.fixes.MixinEndScreenScheduler",
+    "vaulthunters.fixes.MixinIntegrationMinimap",
     "vaulthunters.fixes.MixinSkillDialog",
     "vaulthunters.fixes.MixinTalentWidget",
     "vaulthunters.fixes.MixinToolItemRenderer",


### PR DESCRIPTION
just let user toggle it, same as it was in pre U18

vh minimap will be drawn on top by default, but most people disable it anyway (maybe we should write how to disable it somewhere - quest that doesn't require progression/action bar overlay??)