### PR TITLE
fix: crash because onClientTick in ToolHighlightEvents gets called with every item

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/events/client/ToolHighlightEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/client/ToolHighlightEvents.java
@@ -48,9 +48,18 @@ public class ToolHighlightEvents {
     public static void onClientTick(TickEvent.ClientTickEvent event) {
         if (event.phase != TickEvent.Phase.END) return;
         if (!shouldRefreshToolHighlightCache) return;
-
         Player player = Minecraft.getInstance().player;
         if (player == null || previousPos == null || previousFace == null) return;
+
+        if (!InputEvents.isShiftDown()
+                || ActiveFlags.IS_AOE_MINING.isSet()
+                || player.getMainHandItem().getItem() != ModItems.TOOL
+                || DehammerizerTileEntity.hasDemhammerizerAround(player)) {
+            return;
+        } // TODO ensure its a hammer
+
+
+
 
         Level level = player.getLevel();
         BlockPos pos = previousPos;


### PR DESCRIPTION
this happens rarely when it wants to refresh the cache but the player doesnt have the tool in their hand, missed the conditions that it asks for, woopsie.
sorry for making so many prs 