### PR TITLE
floating item pickup changes

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/items/gear/rang/VaultRangEntity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/items/gear/rang/VaultRangEntity.java
@@ -1,6 +1,7 @@
 package xyz.iwolfking.woldsvaults.items.gear.rang;
 
 import com.google.common.collect.Multimap;
+import iskallia.vault.entity.entity.FloatingItemEntity;
 import iskallia.vault.snapshot.AttributeSnapshotHelper;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import net.minecraft.core.BlockPos;
@@ -383,7 +384,7 @@ public class VaultRangEntity extends Projectile {
 
             Vec3 ourPos = position();
             for(ItemEntity item : items) {
-                if (item.isPassenger())
+                if (item.isPassenger() || item instanceof FloatingItemEntity)
                     continue;
                 item.startRiding(this);
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinFloatingItem.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinFloatingItem.java
@@ -1,17 +1,18 @@
 package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
 
+import iskallia.vault.core.world.storage.IZonedWorld;
+import iskallia.vault.core.world.storage.WorldZone;
 import iskallia.vault.entity.entity.FloatingItemEntity;
-import net.minecraft.world.entity.Entity;
+import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.level.Level;
-import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.util.List;
 
 @Mixin(value = FloatingItemEntity.class, remap = false)
 public abstract class MixinFloatingItem extends ItemEntity {
@@ -19,12 +20,25 @@ public abstract class MixinFloatingItem extends ItemEntity {
         super(pEntityType, pLevel);
     }
 
-    @Unique
-    private int woldsvaults$timer = 0;
+    // make floating items able to be picked up by magnet unless they are in unbreakable vault zone
+    @Inject(method = "tick", at = @At("HEAD"))
+    public void tick(CallbackInfo ci) {
+        if (this.getLevel() instanceof ServerLevel sLevel && this.getTags().contains("PreventMagnetMovement")) {
+            IZonedWorld proxy = IZonedWorld.of(sLevel).orElse(null);
+            if (proxy != null) {
+                var pos = this.blockPosition();
+                List<WorldZone> zones = proxy.getZones().get(pos);
+                if (!zones.isEmpty()) {
+                    for (WorldZone zone : zones) {
+                        if (zone.canModify() == Boolean.FALSE) {
+                            return; // unmodifiable zone => prevent magnet movement (uncompleted raids)
+                        }
+                    }
+                }
 
-    @Inject(method = "<init>(Lnet/minecraft/world/entity/EntityType;Lnet/minecraft/world/level/Level;)V", at = @At("TAIL"))
-    private void removeMagnetTag(EntityType type, Level world, CallbackInfo ci) {
-        this.removeTag("PreventMagnetMovement");
+            }
+            this.removeTag("PreventMagnetMovement");
+        }
     }
 
 }


### PR DESCRIPTION
magnets can no longer pickup floating items in protected zones (for example raid until you press forfeit and loot)
vaultarangs can no longer pickup floating items