### PR TITLE
make safer space effect block obscenely high damage a bit better

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinGearAttributeEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinGearAttributeEvents.java
@@ -119,7 +119,7 @@ public class MixinGearAttributeEvents {
                     CommonEvents.ENTITY_DAMAGE_BLOCK.invoke(new EntityDamageBlockEvent.Data(true, damageSource, attacked));
                 else {
                     event.setCanceled(true);
-                    ((LivingEntityAccessor)attacked).setLastHurt(6.9f*currentAmp);
+                    ((LivingEntityAccessor)attacked).setLastHurt(Math.max(6.9f*currentAmp, event.getAmount()*(1+currentAmp/10.0f)));
                     attacked.invulnerableTime = attacked.invulnerableDuration;
 
                     CommonEvents.ENTITY_DAMAGE_BLOCK.invoke(new EntityDamageBlockEvent.Data(false, damageSource, attacked));


### PR DESCRIPTION
still not *immunity* (the item it's based on doesn't do that, so i don't wanna add it here), but it *should* be able to tank stuff like the oneshot modifier now (unless you accidentally trip it with fall damage or a cactus or something)