### PR TITLE
make smite not target players

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinAbstractSmiteAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinAbstractSmiteAbility.java
@@ -1,0 +1,21 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.skill.ability.effect.spi.AbstractSmiteAbility;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.ArrayList;
+
+@Mixin(AbstractSmiteAbility.class)
+public class MixinAbstractSmiteAbility {
+    @Redirect(method = "doDamage",
+              at = @At(value = "INVOKE",
+                       target = "Ljava/util/ArrayList;remove(Ljava/lang/Object;)Z"),
+              remap = false)
+    private boolean dontSmitePlayers(ArrayList<LivingEntity> array, Object x) {
+        return array.removeIf((entity) -> entity instanceof ServerPlayer);
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -357,6 +357,7 @@
     "vaulthunters.fixes.CardPosMixin",
     "vaulthunters.fixes.MixinAbilityCooldownPercentAttributeReader",
     "vaulthunters.fixes.MixinAbstractEarthquakeAbility",
+    "vaulthunters.fixes.MixinAbstractSmiteAbility",
     "vaulthunters.fixes.MixinAscensionObjective",
     "vaulthunters.fixes.MixinAttributeGearData",
     "vaulthunters.fixes.MixinBailObjective",


### PR DESCRIPTION
smite was apparently targeting players in vaults and it was a bit annoying for someone, so i just made it never target players
could probably do it a bit more thoroughly if the like two pvp players complain though