### PR TITLE
keep taunt from teleporting the vessel

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinTauntAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinTauntAbility.java
@@ -1,0 +1,49 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import iskallia.vault.entity.boss.ArtifactBossEntity;
+import iskallia.vault.entity.boss.TheVesselEntity;
+import iskallia.vault.entity.boss.VaultBossEntity;
+import iskallia.vault.init.ModEffects;
+import java.util.function.Predicate;
+
+import iskallia.vault.skill.ability.effect.TauntAbility;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.Mob;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.ai.targeting.TargetingConditions;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/// aida - allow taunt to target vault bosses, but not teleport them
+@Mixin(value = TauntAbility.class, remap = false)
+public class MixinTauntAbility {
+
+//    // this was making harold do some weird teleporty thing, but idk if that was an intended thing or not, so i just pulled it
+//
+//    /// aida - make harold targetable with taunt
+//    @Redirect(method = "lambda$doAction$1",
+//              at = @At(value = "INVOKE",
+//                       target = "Lnet/minecraft/world/entity/ai/targeting/TargetingConditions;selector(Ljava/util/function/Predicate;)Lnet/minecraft/world/entity/ai/targeting/TargetingConditions;"))
+//    private TargetingConditions doTargetHarold(TargetingConditions conditions, Predicate<LivingEntity> x) {
+//        return conditions.selector(NEW_MONSTER_PREDICATE);
+//    }
+//    @Unique
+//    private static final Predicate<LivingEntity> NEW_MONSTER_PREDICATE = entity -> entity.getType().getCategory() == MobCategory.MONSTER
+//            && entity instanceof Mob
+//            && !entity.hasEffect(ModEffects.TAUNT_CHARM)
+//            && !entity.hasEffect(ModEffects.TAUNT_REPEL_MOB)
+//            && !entity.getTags().contains("ethereal_immune");
+
+    /// aida - make harold and the vessel un-teleportable by taunt
+    @WrapOperation(method = "lambda$doAction$1",
+            at = @At(value = "INVOKE",
+                     target = "Lnet/minecraft/world/entity/Mob;setPos(DDD)V"))
+    private void dontYoinkBosses(Mob mob, double x, double y, double z, Operation<Void> original) {
+        if(!(/*mob instanceof ArtifactBossEntity ||*/ mob instanceof TheVesselEntity || mob instanceof VaultBossEntity))
+            original.call(mob, x, y, z);
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -390,6 +390,7 @@
     "vaulthunters.fixes.MixinScheduledModifiers",
     "vaulthunters.fixes.MixinSpiritExtractorTileEntity",
     "vaulthunters.fixes.MixinStatisticsElementContainerScreenData",
+    "vaulthunters.fixes.MixinTauntAbility",
     "vaulthunters.fixes.MixinThemeBlockRetriever",
     "vaulthunters.fixes.MixinToolItem",
     "vaulthunters.fixes.MixinTreasureDoorTileEntityRenderer",


### PR DESCRIPTION
harold was teleporting when i was testing the *full* thing, but i'd not really looked to see if that was a thing from taunt or just one of the artiboss moves

the full fix would also make harold targetable by taunt