### PR TITLE
Give chests and strongboxes mythic pools + make IR cooler

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/VaultMapTierCache.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/VaultMapTierCache.java
@@ -1,0 +1,26 @@
+package xyz.iwolfking.woldsvaults.api.util;
+
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Map tier (0-5) per running vault, populated when a tier-imprinted crystal configures its
+ * vault and read at strongbox loot generation. Vaults without a tier (regular crystals, or a
+ * server restart mid-vault) simply have no entry and report -1.
+ */
+public class VaultMapTierCache {
+    private static final Map<UUID, Integer> TIER_CACHE = new ConcurrentHashMap<>();
+
+    public static void put(UUID vaultId, int tier) {
+        TIER_CACHE.put(vaultId, tier);
+    }
+
+    public static int get(UUID vaultId) {
+        return TIER_CACHE.getOrDefault(vaultId, -1);
+    }
+
+    public static void invalidate(UUID vaultId) {
+        TIER_CACHE.remove(vaultId);
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/ducks/DuckMapTier.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/ducks/DuckMapTier.java
@@ -1,0 +1,16 @@
+package xyz.iwolfking.woldsvaults.api.util.ducks;
+
+/**
+ * Carries a vault map tier (stored 0-5, display 1-6) on objects that don't natively know it:
+ * the crystal data it is imprinted on at anvil craft, and the strongbox loot generator that
+ * scales by it. -1 means "no tier" and leaves every vanilla code path untouched.
+ */
+public interface DuckMapTier {
+
+    default int getMapTier() {
+        return -1;
+    }
+
+    default void setMapTier(int tier) {
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/items/gear/VaultMapItem.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/items/gear/VaultMapItem.java
@@ -302,7 +302,6 @@ public class VaultMapItem extends BasicItem implements VaultGearItem, IVaultCrys
         applySpecialModifiers(data, mapData, VaultGearModifier.AffixType.SUFFIX, context, output, unfinishedMap);
         applySpecialModifiers(data, mapData, VaultGearModifier.AffixType.IMPLICIT, context, output, unfinishedMap);
 
-        // Imprint the map tier (0-5) on the crystal; strongbox loot scaling reads it back in-vault.
         ((DuckMapTier) (Object) data).setMapTier(mapData.getFirstValue(ModGearAttributes.MAP_TIER).orElse(0));
 
         data.getProperties().setUnmodifiable(true);

--- a/src/main/java/xyz/iwolfking/woldsvaults/items/gear/VaultMapItem.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/items/gear/VaultMapItem.java
@@ -51,6 +51,7 @@ import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import xyz.iwolfking.woldsvaults.api.util.ducks.DuckMapTier;
 import xyz.iwolfking.woldsvaults.init.ModGearAttributes;
 import xyz.iwolfking.woldsvaults.items.lib.IVaultCrystalModifier;
 import xyz.iwolfking.woldsvaults.modifiers.vault.lib.SettableValueVaultModifier;
@@ -301,6 +302,8 @@ public class VaultMapItem extends BasicItem implements VaultGearItem, IVaultCrys
         applySpecialModifiers(data, mapData, VaultGearModifier.AffixType.SUFFIX, context, output, unfinishedMap);
         applySpecialModifiers(data, mapData, VaultGearModifier.AffixType.IMPLICIT, context, output, unfinishedMap);
 
+        // Imprint the map tier (0-5) on the crystal; strongbox loot scaling reads it back in-vault.
+        ((DuckMapTier) (Object) data).setMapTier(mapData.getFirstValue(ModGearAttributes.MAP_TIER).orElse(0));
 
         data.getProperties().setUnmodifiable(true);
         data.write(output);

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
@@ -1,0 +1,44 @@
+package xyz.iwolfking.woldsvaults.loot;
+
+/**
+ * Item-rarity -> sub-pool weight multipliers for the 5-pool (mapped vault) tiered chest tables.
+ * Pools 0-2 behave exactly like vanilla; pool 3 (omega) gains a ramped exponent and pool 4
+ * (mythic) a steeper offset one, so their share keeps growing at high rarity instead of
+ * converging to the base-weight ratio. Tuned ground truth: the pack's loot_analysis/loot_compare.py.
+ */
+public final class MythicLootScaling {
+    /** Sub-pool count of a mapped chest table (4 vanilla tiers + mythic); other tables are untouched. */
+    public static final int MAPPED_POOL_COUNT = 5;
+
+    private static final double LREF = Math.log10(201.0); // ramp normalized to 1 at itemRarity 200 (+20000%)
+    private static final double OMEGA_AMP = 0.12;
+    private static final double MYTHIC_AMP = 0.151;
+    private static final double MYTHIC_OFFSET = 0.70;
+
+    private MythicLootScaling() {
+    }
+
+    /**
+     * Multiplier for sub-pool {@code index}'s base weight; {@code itemRarity} is the rarity
+     * fraction (2.0 == +200%). Non-positive rarity uses the vanilla linear scaling, which also
+     * keeps pow() off negative bases.
+     */
+    public static double poolScale(int index, float itemRarity) {
+        double ir = itemRarity;
+        if (index == 0) {
+            return 1.0;
+        }
+        if (ir <= 0.0) {
+            return 1.0 + ir;
+        }
+        double ramp = Math.pow(Math.log10(1.0 + ir) / LREF, 1.4);
+        switch (index) {
+            case 3:
+                return Math.pow(1.0 + ir, 1.0 + OMEGA_AMP * ramp);
+            case 4:
+                return Math.pow(1.0 + ir, 1.0 + MYTHIC_AMP * ramp + MYTHIC_OFFSET);
+            default:
+                return 1.0 + ir;
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
@@ -10,7 +10,8 @@ public final class MythicLootScaling {
     /** Sub-pool count of a mapped chest table (4 vanilla tiers + mythic); other tables are untouched. */
     public static final int MAPPED_POOL_COUNT = 5;
 
-    private static final double LREF = Math.log10(201.0); // ramp normalized to 1 at itemRarity 200 (+20000%)
+    /** Ramp normalized to 1 at itemRarity 200 (+20000%). */
+    private static final double LREF = Math.log10(201.0);
     private static final double OMEGA_AMP = 0.12;
     private static final double MYTHIC_AMP = 0.151;
     private static final double MYTHIC_OFFSET = 0.70;

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/MythicLootScaling.java
@@ -4,7 +4,7 @@ package xyz.iwolfking.woldsvaults.loot;
  * Item-rarity -> sub-pool weight multipliers for the 5-pool (mapped vault) tiered chest tables.
  * Pools 0-2 behave exactly like vanilla; pool 3 (omega) gains a ramped exponent and pool 4
  * (mythic) a steeper offset one, so their share keeps growing at high rarity instead of
- * converging to the base-weight ratio. Tuned ground truth: the pack's loot_analysis/loot_compare.py.
+ * converging to the base-weight ratio.
  */
 public final class MythicLootScaling {
     /** Sub-pool count of a mapped chest table (4 vanilla tiers + mythic); other tables are untouched. */

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
@@ -1,0 +1,71 @@
+package xyz.iwolfking.woldsvaults.loot;
+
+import iskallia.vault.util.VaultRarity;
+
+/**
+ * Per-map-tier loot scaling for the 5-pool mapped STRONGBOX tables (living/ornate/gilded).
+ * Tier 0 (display tier 1) reproduces the {@link MythicLootScaling} chest curve exactly; each
+ * tier above steepens the pool-3 (omega) and pool-4 (mythic) ramp so their share at +20000%
+ * item rarity rises ~+0.72pp / ~+0.234pp per tier. The boost tables are calibration output
+ * (loot_analysis/strongbox_rework.py); regenerate there rather than hand-tuning. tier = 0..5.
+ */
+public final class StrongboxTierScaling {
+    private static final double LREF = Math.log10(201.0); // ramp normalized to 1 at itemRarity 200 (+20000%)
+    private static final double OMEGA_AMP = 0.12;
+    private static final double MYTHIC_AMP = 0.151;
+    private static final double MYTHIC_OFFSET = 0.70;
+    private static final double[] OMEGA_TIER_BOOST = {0.000, 0.013, 0.025, 0.037, 0.048, 0.059};
+    private static final double[] MYTHIC_TIER_BOOST = {0.000, 0.033, 0.061, 0.086, 0.109, 0.130};
+
+    private StrongboxTierScaling() {
+    }
+
+    /**
+     * Multiplier for sub-pool {@code index}'s base weight; {@code itemRarity} is the rarity
+     * fraction (2.0 == +200%). Non-positive rarity uses the vanilla linear scaling, which also
+     * keeps pow() off negative bases.
+     */
+    public static double poolScale(int index, float itemRarity, int tier) {
+        double ir = itemRarity;
+        if (index == 0) {
+            return 1.0;
+        }
+        if (ir <= 0.0) {
+            return 1.0 + ir;
+        }
+        int t = Math.max(0, Math.min(tier, OMEGA_TIER_BOOST.length - 1));
+        double ramp = Math.pow(Math.log10(1.0 + ir) / LREF, 1.4);
+        switch (index) {
+            case 3:
+                return Math.pow(1.0 + ir, 1.0 + (OMEGA_AMP + OMEGA_TIER_BOOST[t]) * ramp);
+            case 4:
+                return Math.pow(1.0 + ir, 1.0 + (MYTHIC_AMP + MYTHIC_TIER_BOOST[t]) * ramp + MYTHIC_OFFSET);
+            default:
+                return 1.0 + ir;
+        }
+    }
+
+    /** Max loot rolls at this tier: 54 + 18 per display tier (T1 = 72 .. T6 = 162). */
+    public static int maxRolls(int tier) {
+        return 54 + 18 * (tier + 1);
+    }
+
+    /** Extra base rolls before item-quantity scaling (~1.3 per display tier); shifts the IQ needed to cap. */
+    public static int baseRollBonus(int tier) {
+        return Math.round(1.3f * (tier + 1));
+    }
+
+    /**
+     * Displayed rarity by tier. Strongboxes skip the CDF percentile entirely (locked block, the
+     * value is never shown in a GUI), so the cosmetic name/particles track the map tier instead.
+     */
+    public static VaultRarity rarityForTier(int tier) {
+        if (tier >= 4) {
+            return VaultRarity.OMEGA;
+        }
+        if (tier >= 2) {
+            return VaultRarity.EPIC;
+        }
+        return VaultRarity.RARE;
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
@@ -6,8 +6,8 @@ import iskallia.vault.util.VaultRarity;
  * Per-map-tier loot scaling for the 5-pool mapped STRONGBOX tables (living/ornate/gilded).
  * Tier 0 (display tier 1) reproduces the {@link MythicLootScaling} chest curve exactly; each
  * tier above steepens the pool-3 (omega) and pool-4 (mythic) ramp so their share at +20000%
- * item rarity rises ~+0.72pp / ~+0.234pp per tier. The boost tables are calibration output
- * (loot_analysis/strongbox_rework.py); regenerate there rather than hand-tuning. tier = 0..5.
+ * item rarity rises ~+0.72pp / ~+0.234pp per tier. The boost tables are precomputed calibration
+ * output chosen to hit those targets, not hand-tuned values. tier = 0..5.
  */
 public final class StrongboxTierScaling {
     private static final double LREF = Math.log10(201.0); // ramp normalized to 1 at itemRarity 200 (+20000%)

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/StrongboxTierScaling.java
@@ -10,7 +10,8 @@ import iskallia.vault.util.VaultRarity;
  * output chosen to hit those targets, not hand-tuned values. tier = 0..5.
  */
 public final class StrongboxTierScaling {
-    private static final double LREF = Math.log10(201.0); // ramp normalized to 1 at itemRarity 200 (+20000%)
+    /** Ramp normalized to 1 at itemRarity 200 (+20000%). */
+    private static final double LREF = Math.log10(201.0);
     private static final double OMEGA_AMP = 0.12;
     private static final double MYTHIC_AMP = 0.151;
     private static final double MYTHIC_OFFSET = 0.70;

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/TieredCdfApprox.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/TieredCdfApprox.java
@@ -1,0 +1,62 @@
+package xyz.iwolfking.woldsvaults.loot;
+
+/**
+ * O(pools) normal approximation of the tiered-loot rarity percentile
+ * (TieredLootTableGenerator.CDF), used above {@link #EXACT_ROLL_LIMIT} rolls where the exact
+ * composition enumeration balloons (a 5-pool CDF at 54 rolls is ~424k cached BigDecimal terms).
+ * The rarity heuristic H = -sum((total/w_i) * freq_i) is linear in the multinomial counts, so
+ * E[H] = -n*P and Var[H] = n*(sum(score_i) - P^2) in closed form. Ultra-light pools (the 0.00445
+ * mythic pool) are excluded from the fit - their huge score would dominate the variance despite
+ * ~never being hit - and a hit in one is treated as the rarest possible outcome, matching what
+ * the exact enumeration yields for such a draw.
+ */
+public final class TieredCdfApprox {
+    /** Highest roll count that still uses the exact CDF enumeration on 5-pool tables. */
+    public static final int EXACT_ROLL_LIMIT = 30;
+
+    /** Pool probability below which a pool is excluded from the normal fit. */
+    private static final double NEGLIGIBLE = 0.001;
+
+    private TieredCdfApprox() {
+    }
+
+    /** {@code key} = [rollCount, baseWeight_0 .. baseWeight_{P-1}], exactly as built in generate(). */
+    public static double cdf(double[] key, int[] frequencies) {
+        int pools = key.length - 1;
+        double n = key[0];
+        double total = 0.0;
+        for (int i = 1; i <= pools; i++) {
+            total += key[i];
+        }
+        double sumScores = 0.0;
+        double hObs = 0.0;
+        int active = 0;
+        for (int i = 0; i < pools; i++) {
+            if (key[i + 1] / total < NEGLIGIBLE) {
+                if (frequencies[i] > 0) {
+                    return 0.0;
+                }
+                continue;
+            }
+            double score = total / key[i + 1];
+            sumScores += score;
+            hObs -= score * frequencies[i];
+            active++;
+        }
+        double mean = -n * active;
+        double var = n * (sumScores - (double) active * active);
+        if (var <= 0.0) {
+            return hObs <= mean ? 0.0 : 1.0; // degenerate: single active pool / all weights equal
+        }
+        return phi((hObs - mean) / Math.sqrt(var));
+    }
+
+    /** Standard normal CDF, Abramowitz-Stegun 7.1.26 (|error| < 7.5e-8). */
+    private static double phi(double z) {
+        double t = 1.0 / (1.0 + 0.2316419 * Math.abs(z));
+        double d = 0.3989422804014327 * Math.exp(-0.5 * z * z);
+        double p = d * t * (0.319381530 + t * (-0.356563782 + t * (1.781477937
+                + t * (-1.821255978 + t * 1.330274429))));
+        return z >= 0.0 ? 1.0 - p : p;
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/loot/TieredCdfApprox.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/loot/TieredCdfApprox.java
@@ -20,7 +20,11 @@ public final class TieredCdfApprox {
     private TieredCdfApprox() {
     }
 
-    /** {@code key} = [rollCount, baseWeight_0 .. baseWeight_{P-1}], exactly as built in generate(). */
+    /**
+     * {@code key} = [rollCount, baseWeight_0 .. baseWeight_{P-1}], exactly as built in
+     * generate(). A degenerate fit (single active pool, or all weights equal) resolves to
+     * 0 or 1 directly.
+     */
     public static double cdf(double[] key, int[] frequencies) {
         int pools = key.length - 1;
         double n = key[0];
@@ -46,7 +50,7 @@ public final class TieredCdfApprox {
         double mean = -n * active;
         double var = n * (sumScores - (double) active * active);
         if (var <= 0.0) {
-            return hObs <= mean ? 0.0 : 1.0; // degenerate: single active pool / all weights equal
+            return hObs <= mean ? 0.0 : 1.0;
         }
         return phi((hObs - mean) / Math.sqrt(var));
     }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
@@ -117,6 +117,11 @@ public class MixinTieredLootTableGenerator implements DuckMapTier {
         return original.call(cache, cdfKey, factory);
     }
 
+    /**
+     * Pairs with {@link #routeCdfBuild}: when the CDF build was skipped, strongboxes resolve
+     * 1.0 (the value is never read - rarity comes from the map tier) and mapped chests resolve
+     * the Gaussian approximation.
+     */
     @WrapOperation(
             method = "generate",
             at = @At(value = "INVOKE", target = "Liskallia/vault/core/world/loot/generator/TieredLootTableGenerator$CDF;get([I)D")
@@ -125,7 +130,6 @@ public class MixinTieredLootTableGenerator implements DuckMapTier {
         if (cdf != null) {
             return original.call(cdf, frequencies);
         }
-        // Strongbox: value is never read (rarity comes from the tier). Chest: Gaussian approximation.
         return this.woldsvaults$mapTier >= 0 ? 1.0 : TieredCdfApprox.cdf(this.key, frequencies);
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
@@ -10,15 +10,40 @@ import iskallia.vault.core.world.loot.generator.TieredLootTableGenerator;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
+import xyz.iwolfking.woldsvaults.api.util.ducks.DuckMapTier;
 import xyz.iwolfking.woldsvaults.loot.MythicLootScaling;
+import xyz.iwolfking.woldsvaults.loot.StrongboxTierScaling;
+import xyz.iwolfking.woldsvaults.loot.TieredCdfApprox;
+
+import java.util.Map;
+import java.util.function.Function;
 
 @Mixin(value = TieredLootTableGenerator.class, remap = false)
-public class MixinTieredLootTableGenerator {
+public class MixinTieredLootTableGenerator implements DuckMapTier {
     @Shadow
     private double[] key;
     @Shadow
     public float itemRarity;
+
+    /**
+     * Map tier (0-5) of the mapped strongbox this generator rolls for, set by the chest tile
+     * entity mixin before generate() runs. -1 (everything that is not a mapped strongbox) keeps
+     * every path below identical to the chest behavior.
+     */
+    @Unique
+    private int woldsvaults$mapTier = -1;
+
+    @Override
+    public int getMapTier() {
+        return this.woldsvaults$mapTier;
+    }
+
+    @Override
+    public void setMapTier(int tier) {
+        this.woldsvaults$mapTier = tier;
+    }
 
     @ModifyExpressionValue(
             method = "generate",
@@ -28,11 +53,31 @@ public class MixinTieredLootTableGenerator {
         return 1.1f * (float) Math.log(originalValue + 1.0f);
     }
 
+    /** Mapped strongboxes add a few base rolls per tier, lifting the whole quantity curve. */
+    @ModifyExpressionValue(
+            method = "generate",
+            at = @At(value = "INVOKE", target = "Liskallia/vault/core/world/roll/IntRoll;get(Liskallia/vault/core/random/RandomSource;)I")
+    )
+    private int addStrongboxBaseRolls(int roll) {
+        return this.woldsvaults$mapTier >= 0 ? roll + StrongboxTierScaling.baseRollBonus(this.woldsvaults$mapTier) : roll;
+    }
+
+    /** Mapped strongboxes cap at 72-162 rolls by tier instead of the constructor's 54. */
+    @ModifyExpressionValue(
+            method = "generate",
+            at = @At(value = "FIELD", target = "Liskallia/vault/core/world/loot/generator/TieredLootTableGenerator;maxRolls:I", opcode = Opcodes.GETFIELD)
+    )
+    private int raiseStrongboxMaxRolls(int maxRolls) {
+        return this.woldsvaults$mapTier >= 0 ? StrongboxTierScaling.maxRolls(this.woldsvaults$mapTier) : maxRolls;
+    }
+
     /**
      * Replaces the uniform weight * (1 + itemRarity) sub-pool scaling with per-pool curves on
      * 5-pool (mapped vault) tables; 4-pool tables keep the incoming vanilla weight. generate()
      * fills key = [roll, w0..wn-1] before generateEntry, and the adjusted pool being built here
      * holds one child per already-scaled sub-pool, giving the base weight and pool index directly.
+     * Mapped strongboxes (mapTier >= 0) use the tier-steepened strongbox curves; mapped chests
+     * keep the plain mythic curve.
      */
     @WrapOperation(
             method = "generateEntry",
@@ -41,9 +86,46 @@ public class MixinTieredLootTableGenerator {
     private WeightedTree<LootEntry> alterItemRarityScaling(LootPool adjustedPool, WeightedTree<LootEntry> childPool, double weight, Operation<WeightedTree<LootEntry>> original) {
         if (this.key != null && this.key.length - 1 == MythicLootScaling.MAPPED_POOL_COUNT) {
             int index = adjustedPool.getChildren().size();
-            weight = this.key[index + 1] * MythicLootScaling.poolScale(index, this.itemRarity);
+            double scale = this.woldsvaults$mapTier >= 0
+                    ? StrongboxTierScaling.poolScale(index, this.itemRarity, this.woldsvaults$mapTier)
+                    : MythicLootScaling.poolScale(index, this.itemRarity);
+            weight = this.key[index + 1] * scale;
         }
         return original.call(adjustedPool, childPool, weight);
     }
 
+    /**
+     * Routes the rarity-percentile CDF three ways. Strongboxes skip it entirely - their rarity
+     * comes from the map tier, and building the exact CDF at a T6 strongbox's 162 rolls would
+     * enumerate ~30M compositions (multi-second freeze, GBs of cache). 5-pool mapped-chest
+     * tables above EXACT_ROLL_LIMIT rolls use the O(pools) Gaussian approximation instead of
+     * growing the exact cache into the hundreds of MB lategame. Everything else (4-pool tables,
+     * low-roll 5-pool tables) keeps the exact enumeration. Returning null skips CDF::new; the
+     * paired wrap below turns the null into the substitute value.
+     */
+    @WrapOperation(
+            method = "generate",
+            at = @At(value = "INVOKE", target = "Ljava/util/Map;computeIfAbsent(Ljava/lang/Object;Ljava/util/function/Function;)Ljava/lang/Object;")
+    )
+    private Object routeCdfBuild(Map<Object, Object> cache, Object cdfKey, Function<Object, Object> factory, Operation<Object> original) {
+        if (this.woldsvaults$mapTier >= 0) {
+            return null;
+        }
+        if (this.key.length - 1 == MythicLootScaling.MAPPED_POOL_COUNT && this.key[0] > TieredCdfApprox.EXACT_ROLL_LIMIT) {
+            return null;
+        }
+        return original.call(cache, cdfKey, factory);
+    }
+
+    @WrapOperation(
+            method = "generate",
+            at = @At(value = "INVOKE", target = "Liskallia/vault/core/world/loot/generator/TieredLootTableGenerator$CDF;get([I)D")
+    )
+    private double routeCdfValue(TieredLootTableGenerator.CDF cdf, int[] frequencies, Operation<Double> original) {
+        if (cdf != null) {
+            return original.call(cdf, frequencies);
+        }
+        // Strongbox: value is never read (rarity comes from the tier). Chest: Gaussian approximation.
+        return this.woldsvaults$mapTier >= 0 ? 1.0 : TieredCdfApprox.cdf(this.key, frequencies);
+    }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/MixinTieredLootTableGenerator.java
@@ -1,13 +1,24 @@
 package xyz.iwolfking.woldsvaults.mixins.vaulthunters;
 
 import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import iskallia.vault.core.util.WeightedTree;
+import iskallia.vault.core.world.loot.LootPool;
+import iskallia.vault.core.world.loot.entry.LootEntry;
 import iskallia.vault.core.world.loot.generator.TieredLootTableGenerator;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import xyz.iwolfking.woldsvaults.loot.MythicLootScaling;
 
 @Mixin(value = TieredLootTableGenerator.class, remap = false)
 public class MixinTieredLootTableGenerator {
+    @Shadow
+    private double[] key;
+    @Shadow
+    public float itemRarity;
 
     @ModifyExpressionValue(
             method = "generate",
@@ -15,6 +26,24 @@ public class MixinTieredLootTableGenerator {
     )
     private float alterItemQuantityScaling(float originalValue) {
         return 1.1f * (float) Math.log(originalValue + 1.0f);
+    }
+
+    /**
+     * Replaces the uniform weight * (1 + itemRarity) sub-pool scaling with per-pool curves on
+     * 5-pool (mapped vault) tables; 4-pool tables keep the incoming vanilla weight. generate()
+     * fills key = [roll, w0..wn-1] before generateEntry, and the adjusted pool being built here
+     * holds one child per already-scaled sub-pool, giving the base weight and pool index directly.
+     */
+    @WrapOperation(
+            method = "generateEntry",
+            at = @At(value = "INVOKE", target = "Liskallia/vault/core/world/loot/LootPool;addTree(Liskallia/vault/core/util/WeightedTree;D)Liskallia/vault/core/util/WeightedTree;")
+    )
+    private WeightedTree<LootEntry> alterItemRarityScaling(LootPool adjustedPool, WeightedTree<LootEntry> childPool, double weight, Operation<WeightedTree<LootEntry>> original) {
+        if (this.key != null && this.key.length - 1 == MythicLootScaling.MAPPED_POOL_COUNT) {
+            int index = adjustedPool.getChildren().size();
+            weight = this.key[index + 1] * MythicLootScaling.poolScale(index, this.itemRarity);
+        }
+        return original.call(adjustedPool, childPool, weight);
     }
 
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinCrystalMapTier.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinCrystalMapTier.java
@@ -1,0 +1,61 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.custom;
+
+import iskallia.vault.core.random.RandomSource;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.item.crystal.CrystalData;
+import net.minecraft.nbt.CompoundTag;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import xyz.iwolfking.woldsvaults.api.util.VaultMapTierCache;
+import xyz.iwolfking.woldsvaults.api.util.ducks.DuckMapTier;
+
+import java.util.Optional;
+
+/**
+ * Carries the map tier (0-5) on the crystal: imprinted at anvil craft (VaultMapItem), kept
+ * through the NBT round-trips of CrystalData.copy()/read()/write(), and stashed into
+ * {@link VaultMapTierCache} when the crystal configures its vault so strongbox loot generation
+ * can read it. Crystals without a tier never write the tag and never touch the cache.
+ */
+@Mixin(value = CrystalData.class, remap = false)
+public class MixinCrystalMapTier implements DuckMapTier {
+    @Unique
+    private static final String MAP_TIER_TAG = "woldsvaults:map_tier";
+
+    @Unique
+    private int woldsvaults$mapTier = -1;
+
+    @Override
+    public int getMapTier() {
+        return this.woldsvaults$mapTier;
+    }
+
+    @Override
+    public void setMapTier(int tier) {
+        this.woldsvaults$mapTier = tier;
+    }
+
+    @Inject(method = "writeNbt", at = @At("RETURN"))
+    private void writeMapTier(CallbackInfoReturnable<Optional<CompoundTag>> cir) {
+        if (this.woldsvaults$mapTier >= 0) {
+            cir.getReturnValue().ifPresent(nbt -> nbt.putInt(MAP_TIER_TAG, this.woldsvaults$mapTier));
+        }
+    }
+
+    // HEAD, not TAIL: readNbt reassigns its nbt local to an upgraded copy, so read the original.
+    @Inject(method = "readNbt", at = @At("HEAD"))
+    private void readMapTier(CompoundTag nbt, CallbackInfo ci) {
+        this.woldsvaults$mapTier = nbt.contains(MAP_TIER_TAG) ? nbt.getInt(MAP_TIER_TAG) : -1;
+    }
+
+    @Inject(method = "configure", at = @At("TAIL"))
+    private void stashMapTierForVault(Vault vault, RandomSource random, String sigil, CallbackInfo ci) {
+        if (this.woldsvaults$mapTier >= 0 && vault.has(Vault.ID)) {
+            VaultMapTierCache.put(vault.get(Vault.ID), this.woldsvaults$mapTier);
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinCrystalMapTier.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinCrystalMapTier.java
@@ -46,7 +46,7 @@ public class MixinCrystalMapTier implements DuckMapTier {
         }
     }
 
-    // HEAD, not TAIL: readNbt reassigns its nbt local to an upgraded copy, so read the original.
+    /** HEAD, not TAIL: readNbt reassigns its nbt local to an upgraded copy, so read the original. */
     @Inject(method = "readNbt", at = @At("HEAD"))
     private void readMapTier(CompoundTag nbt, CallbackInfo ci) {
         this.woldsvaults$mapTier = nbt.contains(MAP_TIER_TAG) ? nbt.getInt(MAP_TIER_TAG) : -1;

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinVaultCacheInvalidator.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinVaultCacheInvalidator.java
@@ -6,6 +6,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.iwolfking.woldsvaults.api.util.RoyaleVaultCache;
+import xyz.iwolfking.woldsvaults.api.util.VaultMapTierCache;
 
 @Mixin(value = Vault.class, remap = false)
 public class MixinVaultCacheInvalidator {
@@ -15,6 +16,7 @@ public class MixinVaultCacheInvalidator {
         Vault vault = (Vault) (Object) this;
         if (vault.has(Vault.ID)) {
             RoyaleVaultCache.invalidate(vault.get(Vault.ID));
+            VaultMapTierCache.invalidate(vault.get(Vault.ID));
         }
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultChestTileEntity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultChestTileEntity.java
@@ -1,25 +1,98 @@
 package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
 
+import com.llamalad7.mixinextras.injector.ModifyExpressionValue;
 import iskallia.vault.block.entity.VaultChestTileEntity;
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.VaultUtils;
+import iskallia.vault.core.world.loot.generator.TieredLootTableGenerator;
 import iskallia.vault.init.ModBlocks;
+import iskallia.vault.util.VaultRarity;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Constant;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyConstant;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.iwolfking.woldsvaults.api.util.VaultMapTierCache;
+import xyz.iwolfking.woldsvaults.api.util.ducks.DuckMapTier;
+import xyz.iwolfking.woldsvaults.loot.StrongboxTierScaling;
 
+/**
+ * Chest sizes plus the mapped-strongbox tier wiring: resolves the running vault's map tier when
+ * a strongbox generates loot, hands it to the loot generator (tier-scaled pools/rolls), derives
+ * the displayed rarity from the tier, and lets loot fill the whole 81-slot box instead of the
+ * first 27 slots. Strongboxes outside a tiered vault (regular vaults, or no cache entry after a
+ * server restart) resolve tier -1 and behave exactly as before.
+ */
 @Mixin(value = VaultChestTileEntity.class, remap = false)
 public class MixinVaultChestTileEntity {
+    /** Map tier of the vault this chest generates in; -1 for everything but mapped strongboxes. */
+    @Unique
+    private int woldsvaults$mapTier = -1;
+
     /**
-     * @author
-     * @reason
+     * @author iwolfking
+     * @reason Resize strongboxes to 81 slots. Strongboxes are locked (no GUI), so the vanilla
+     * ChestMenu 54-slot ceiling never applies; loot only drops on break.
      */
     @Overwrite
     private int getSize(BlockState state) {
         Block block = state.getBlock();
-        if (block != ModBlocks.TREASURE_CHEST && block != ModBlocks.TREASURE_CHEST_PLACEABLE) {
-            return block != ModBlocks.WOODEN_CHEST && block != ModBlocks.WOODEN_CHEST_PLACEABLE && block != ModBlocks.WOODEN_BARREL ? 45 : 36;
-        } else {
+        if (block == ModBlocks.TREASURE_CHEST || block == ModBlocks.TREASURE_CHEST_PLACEABLE) {
             return 54;
         }
+        if (block == ModBlocks.WOODEN_CHEST || block == ModBlocks.WOODEN_CHEST_PLACEABLE || block == ModBlocks.WOODEN_BARREL) {
+            return 36;
+        }
+        if (woldsvaults$isStrongbox(block)) {
+            return 81;
+        }
+        return 45;
+    }
+
+    @Unique
+    private static boolean woldsvaults$isStrongbox(Block block) {
+        return block == ModBlocks.GILDED_STRONGBOX || block == ModBlocks.ORNATE_STRONGBOX || block == ModBlocks.LIVING_STRONGBOX;
+    }
+
+    @Inject(method = "generateLootTable", at = @At("HEAD"))
+    private void resolveStrongboxMapTier(CallbackInfo ci) {
+        VaultChestTileEntity self = (VaultChestTileEntity) (Object) this;
+        this.woldsvaults$mapTier = woldsvaults$isStrongbox(self.getBlockState().getBlock())
+                ? VaultUtils.getVault(self.getLevel())
+                        .filter(vault -> vault.has(Vault.ID))
+                        .map(vault -> VaultMapTierCache.get(vault.get(Vault.ID)))
+                        .orElse(-1)
+                : -1;
+    }
+
+    @ModifyExpressionValue(
+            method = "generateLootTable",
+            at = @At(value = "NEW", target = "iskallia/vault/core/world/loot/generator/TieredLootTableGenerator")
+    )
+    private TieredLootTableGenerator passMapTierToGenerator(TieredLootTableGenerator generator) {
+        if (this.woldsvaults$mapTier >= 0) {
+            ((DuckMapTier) (Object) generator).setMapTier(this.woldsvaults$mapTier);
+        }
+        return generator;
+    }
+
+    /** Strongboxes never compute the CDF percentile, so their rarity tracks the map tier instead. */
+    @ModifyExpressionValue(
+            method = "generateLootTable",
+            at = @At(value = "INVOKE", target = "Liskallia/vault/config/VaultChestConfig;getRarity(D)Liskallia/vault/util/VaultRarity;")
+    )
+    private VaultRarity rarityFromMapTier(VaultRarity rarity) {
+        return this.woldsvaults$mapTier >= 0 ? StrongboxTierScaling.rarityForTier(this.woldsvaults$mapTier) : rarity;
+    }
+
+    /** Tiered strongboxes fill their full 81 slots; every other non-treasure chest keeps the 27 cap. */
+    @ModifyConstant(method = {"generateChestLoot", "fillLoot", "getAvailableSlots"}, constant = @Constant(intValue = 27))
+    private int raiseStrongboxFillCap(int fillCap) {
+        return this.woldsvaults$mapTier >= 0 ? ((VaultChestTileEntity) (Object) this).getContainerSize() : fillCap;
     }
 }

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -245,6 +245,7 @@
     "vaulthunters.custom.MixinCompanionEggHunt",
     "vaulthunters.custom.MixinCompanionItem",
     "vaulthunters.custom.MixinCorruptGearModification",
+    "vaulthunters.custom.MixinCrystalMapTier",
     "vaulthunters.custom.MixinCrystalModifiers",
     "vaulthunters.custom.MixinCrystalWorkbenchContainer",
     "vaulthunters.custom.MixinCrystalWorkbenchTileEntity",


### PR DESCRIPTION
Adds plumbing map-exclusive mythic chest roll pools to living, gilded, ornate, and wooden chests, and makes them scale more interestingly with IR to prevent the asymptotic useless falloff of high levels of IR.  Has a new function to parse the 5 pool system, any chests fed into the loot generator with 4 pools acts as normal (so regular maps, and any other chest type). also swaps to a gaussian distribution to calculate chest rarities for larger chests, to prevent the abomination that is the chest-roll cache used to determine chest rarity from OOM-ing the client. Exact details of what the new loot rolls look like are published on discord, but they aren't crazy.

---

Technical notes: the strongbox half of this is per-map-tier — the map tier (1-6) is imprinted on the crystal at anvil craft and read back at loot generation, so mapped strongboxes get tier-scaled roll caps (72-162), a tier-derived displayed rarity, and fill all 81 slots instead of the first 27. A server restart mid-vault clears the tier stash and those strongboxes fall back to fully vanilla behavior for that run. Everything is gated on a -1 "no tier" sentinel, so every non-mapped chest path is byte-identical to before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)