### PR TITLE
Fix greed crate bonus multiplying with every live Runner on the server

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinRunner.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinRunner.java
@@ -3,6 +3,7 @@ package xyz.iwolfking.woldsvaults.mixins.vaulthunters.custom;
 import iskallia.vault.VaultMod;
 import iskallia.vault.core.Version;
 import iskallia.vault.core.event.CommonEvents;
+import iskallia.vault.core.event.common.CrateAwardEvent;
 import iskallia.vault.core.event.common.FruitEatenEvent;
 import iskallia.vault.core.random.ChunkRandom;
 import iskallia.vault.core.vault.Vault;
@@ -48,6 +49,7 @@ import xyz.iwolfking.woldsvaults.api.util.VaultModifierUtils;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 
 @Mixin(value = Runner.class, remap = false)
@@ -57,6 +59,15 @@ public abstract class MixinRunner extends Listener {
     @Inject(method = "initServer", at = @At("TAIL"))
     private void addGreedCoinsToCrate(VirtualWorld world, Vault vault, CallbackInfo ci) {
         CommonEvents.CRATE_AWARD_EVENT.register(this, event -> {
+            // CRATE_AWARD_EVENT is a server-global bus invoked twice (PRE/POST) for every
+            // crate awarded in ANY vault; without these guards each live Runner injects a
+            // full bonus roll into every crate on the server.
+            if(event.getPhase() != CrateAwardEvent.Phase.PRE) {
+                return;
+            }
+            if(event.getListener() == null || !Objects.equals(event.getListener().get(Listener.ID), this.get(Listener.ID))) {
+                return;
+            }
             int greedTier = PlayerGreedTreeData.get(event.getPlayer().getLevel()).getGreedTier(event.getPlayer().getUUID());
             if(vault.get(Vault.LEVEL).get(VaultLevel.VALUE) >= 100 && greedTier > 0 && !VaultUtils.isRoyaleVault(vault) && !VaultUtils.isBrazierVault(vault) && !VaultUtils.isCakeVault(vault) && !VaultUtils.isSpecialVault(vault)) {
                 ResourceLocation lootTableKey = WoldsVaults.id("greed_crate_bonus_scavenger");


### PR DESCRIPTION
### Bug
`MixinRunner#addGreedCoinsToCrate` registers its handler on `CommonEvents.CRATE_AWARD_EVENT` once per `Runner`, but that event is a single server-global bus: `AwardCrateObjective#awardCrate` invokes it for every completion crate awarded in every vault (twice - `PRE` and `POST`), and the handler never checked which listener's crate was being generated.

Consequences:
- In a party of N, every crate receives ~N full greed-bonus rolls (each pass re-applies the recipient's `greedTier - 1` coin bump, plus the foci/vault gold/misc entries). Observed on a live server: tier-16 brutal-boss crates at ~110-140 greed coins in a 4-6 player group vs ~18-20 intended.
- Runners in *other* concurrent vaults inject too, so even solo crate contents scale with overall server activity.
- The level-100 gate and the royale/brazier/cake/special exclusions are evaluated against the *injector's* captured vault, not the crate owner's vault - excluded or sub-100 vaults still receive bonuses whenever someone else is running an eligible vault.
- The `POST` invocation rolled the table a second time into an already-consumed `additionalItems` list (wasted work today, a latent dupe risk if the award flow ever changes).

### Fix
Bail out unless the event is `Phase.PRE` and the event's listener is the runner that registered the handler (same `Listener.ID`). One injection per crate, gated by the recipient's own vault and greed tier. Matches the handler pattern base VH itself uses in `VaultDollItem#handleCrateLoot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)