### PR TITLE
Add bleed kill credit and reduce percent damage against major bosses

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/ConcentrateAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/ConcentrateAbility.java
@@ -31,6 +31,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import xyz.iwolfking.woldsvaults.WoldsVaults;
 import xyz.iwolfking.woldsvaults.api.util.AbilityHelper;
 import xyz.iwolfking.woldsvaults.api.util.DelayedExecutionHelper;
+import xyz.iwolfking.woldsvaults.events.HyperVaultEvents;
 import xyz.iwolfking.woldsvaults.init.ModEffects;
 import xyz.iwolfking.woldsvaults.init.ModEtchingGearAttributes;
 
@@ -99,9 +100,13 @@ public class ConcentrateAbility extends InstantManaAbility {
                         effectsToProcess.add(Pair.of(entity.position(), positive));
                     }
                 }
+                boolean drainDenied = drainEtchingAttribute != null && HyperVaultEvents.isHyperBoss(entity);
+                if(drainDenied && !effectsToRemove.isEmpty()) {
+                    WoldsVaults.LOGGER.info("Skipped Concentrated Drain etching damage on a hyperboss ({} effect(s) drained).", effectsToRemove.size());
+                }
                 for(MobEffect effect : effectsToRemove) {
                     entity.removeEffect(effect);
-                    if(drainEtchingAttribute != null) {
+                    if(drainEtchingAttribute != null && !drainDenied) {
                         entity.hurt(DamageSource.MAGIC, Math.min(entity.getHealth() * drainEtchingAttribute.getValue(), 3 * AbilityHelper.getAbilityLevel(serverPlayer, "Concentrate_Base")));
                         serverPlayer.heal(1);
                     }

--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/BleedSourceRegistry.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/BleedSourceRegistry.java
@@ -1,0 +1,64 @@
+package xyz.iwolfking.woldsvaults.api.util;
+
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.EntityDamageSource;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+public class BleedSourceRegistry {
+    private static final Map<UUID, UUID> bleedSources = new HashMap<>();
+
+    private static final DamageSource UNATTRIBUTED_BLEED = new UnattributedBleedSource();
+
+    /**
+     * Records the entity responsible for the most recent Bleed application on the target so
+     * Bleed damage ticks can be attributed to it for kill credit.
+     */
+    public static void registerSource(LivingEntity target, Entity source) {
+        if (source != null) {
+            bleedSources.put(target.getUUID(), source.getUUID());
+        }
+    }
+
+    public static void removeSource(LivingEntity target) {
+        bleedSources.remove(target.getUUID());
+    }
+
+    /**
+     * Resolves the damage source for a Bleed tick, attributed to the registered applier when
+     * one is known and still loaded. Every returned source bypasses armor and magic reduction
+     * so percent Bleed always deals its full listed damage.
+     */
+    public static DamageSource resolveDamageSource(LivingEntity entity) {
+        UUID sourceId = bleedSources.get(entity.getUUID());
+        if (sourceId != null && entity.level instanceof ServerLevel serverLevel) {
+            Entity sourceEntity = serverLevel.getEntity(sourceId);
+            if (sourceEntity instanceof LivingEntity living) {
+                return new BleedDamageSource(living instanceof Player ? "player" : "mob", living);
+            }
+        }
+        return UNATTRIBUTED_BLEED;
+    }
+
+    private static final class BleedDamageSource extends EntityDamageSource {
+        private BleedDamageSource(String msgId, Entity source) {
+            super(msgId, source);
+            this.bypassArmor();
+            this.bypassMagic();
+        }
+    }
+
+    private static final class UnattributedBleedSource extends DamageSource {
+        private UnattributedBleedSource() {
+            super("generic");
+            this.bypassArmor();
+            this.bypassMagic();
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/VaultMobUtils.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/VaultMobUtils.java
@@ -1,16 +1,32 @@
 package xyz.iwolfking.woldsvaults.api.util;
 
 import iskallia.vault.entity.VaultBoss;
+import iskallia.vault.entity.boss.VaultBossEntity;
 import iskallia.vault.entity.champion.ChampionLogic;
 import iskallia.vault.entity.entity.elite.EliteModifierImmunity;
 import net.minecraft.world.entity.Entity;
 
 public class VaultMobUtils {
+    public static final String BRUTAL_BOSS_TAG = "woldsvaults_brutal_boss";
+
     public static boolean isEliteMob(Entity entity) {
         return entity instanceof EliteModifierImmunity;
     }
 
     public static boolean isSpecialMob(Entity entity) {
         return isEliteMob(entity) || ChampionLogic.isChampion(entity) || entity instanceof VaultBoss;
+    }
+
+    public static boolean isBrutalBoss(Entity entity) {
+        return entity.getTags().contains(BRUTAL_BOSS_TAG);
+    }
+
+    /**
+     * Checks for the heavyweight boss tier: rune boss entities (including the hyper
+     * objective's hyperbosses, which are escalated rune bosses) and Brutal Bosses
+     * objective spawns.
+     */
+    public static boolean isMajorBoss(Entity entity) {
+        return entity instanceof VaultBossEntity || isBrutalBoss(entity);
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/events/HyperVaultEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/HyperVaultEvents.java
@@ -40,7 +40,11 @@ public final class HyperVaultEvents {
                 .orElse(false);
     }
 
-    static boolean isHyperBoss(LivingEntity entity) {
+    /**
+     * Checks whether the entity is the hyper objective's boss: a rune boss entity inside a
+     * hyper vault.
+     */
+    public static boolean isHyperBoss(LivingEntity entity) {
         return entity instanceof VaultBossEntity && isInHyperVault(entity);
     }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
@@ -71,6 +71,7 @@ import top.theillusivec4.curios.api.CuriosApi;
 import top.theillusivec4.curios.api.event.CurioChangeEvent;
 import xyz.iwolfking.woldsvaults.WoldsVaults;
 import xyz.iwolfking.woldsvaults.abilities.SneakyGetawayAbility;
+import xyz.iwolfking.woldsvaults.api.util.BleedSourceRegistry;
 import xyz.iwolfking.woldsvaults.api.util.WoldAttributeHelper;
 import xyz.iwolfking.woldsvaults.api.util.WoldEtchingHelper;
 import xyz.iwolfking.woldsvaults.config.forge.WoldsVaultsConfig;
@@ -358,6 +359,7 @@ public class LivingEntityEvents {
                 }
 
                 EtchingHelper.getEtchings(player, ModEtchingGearAttributes.REAVING_HEMMORAGE).stream().findFirst().ifPresent(reavingHemmorageAttribute -> {
+                    BleedSourceRegistry.registerSource(event.getEntityLiving(), player);
                     event.getEntityLiving().addEffect(new MobEffectInstance(iskallia.vault.init.ModEffects.BLEED, 160, reavingHemmorageAttribute.getValue()));
                 });
 
@@ -473,6 +475,10 @@ public class LivingEntityEvents {
                     MobEffectInstance instance = HexEffects.HEX_EFFECTS.getRandom(player.getRandom());
                     if(instance == null){
                         return;
+                    }
+
+                    if(instance.getEffect() == iskallia.vault.init.ModEffects.BLEED) {
+                        BleedSourceRegistry.registerSource(event.getEntityLiving(), player);
                     }
 
                     event.getEntityLiving().addEffect(new MobEffectInstance(instance));

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinBleedEffect.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinBleedEffect.java
@@ -1,21 +1,25 @@
 package xyz.iwolfking.woldsvaults.mixins.vaulthunters.custom;
 
 import iskallia.vault.effect.BleedEffect;
-import iskallia.vault.entity.VaultBoss;
-import iskallia.vault.entity.champion.ChampionLogic;
+import iskallia.vault.entity.boss.TheVesselEntity;
+import iskallia.vault.event.ActiveFlags;
 import iskallia.vault.init.ModEffects;
+import iskallia.vault.util.damage.DamageUtil;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.entity.LivingEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
+import xyz.iwolfking.woldsvaults.api.util.BleedSourceRegistry;
 import xyz.iwolfking.woldsvaults.api.util.VaultMobUtils;
 
 @Mixin(value = BleedEffect.class, remap = false)
 public class MixinBleedEffect {
     /**
      * @author iwolfking
-     * @reason Change Bleed to do a portion of max health per damage tick instead.
+     * @reason Change Bleed to do a portion of max health per damage tick instead, attributed
+     * to the applier for kill credit and scaled down against major bosses and the Vessel.
      */
     @Overwrite(remap = true)
     public void applyEffectTick(LivingEntity entity, int amplifier) {
@@ -25,18 +29,30 @@ public class MixinBleedEffect {
                 if (instance.getDuration() % 40 == 0) {
                     float maxHealthPercent = instance.getAmplifier() * 0.025F;
 
-                    if(VaultMobUtils.isSpecialMob(entity)) {
-                        maxHealthPercent = maxHealthPercent * 0.5f;
+                    if (entity instanceof TheVesselEntity) {
+                        maxHealthPercent = maxHealthPercent * 0.01F;
+                    }
+                    else if (VaultMobUtils.isMajorBoss(entity)) {
+                        maxHealthPercent = maxHealthPercent * 0.1F;
+                    }
+                    else if (VaultMobUtils.isSpecialMob(entity)) {
+                        maxHealthPercent = maxHealthPercent * 0.5F;
                     }
 
                     float healthReduction = Math.max((entity.getMaxHealth() * maxHealthPercent), instance.getAmplifier() + 1);
+                    DamageSource source = BleedSourceRegistry.resolveDamageSource(entity);
+                    Runnable damageTask = () -> DamageUtil.shotgunAttack(entity, e -> e.hurt(source, healthReduction));
 
-                    entity.setHealth(entity.getHealth() - healthReduction);
-                    if (entity.isDeadOrDying()) {
-                        entity.die(DamageSource.MAGIC);
+                    if (source.getEntity() instanceof ServerPlayer) {
+                        ActiveFlags.IS_AP_ATTACKING.runIfNotSet(() -> ActiveFlags.IS_EFFECT_ATTACKING.runIfNotSet(damageTask));
+                    } else {
+                        ActiveFlags.IS_EFFECT_ATTACKING.runIfNotSet(damageTask);
                     }
                 }
 
+                if (instance.getDuration() <= 1) {
+                    BleedSourceRegistry.removeSource(entity);
+                }
             }
         }
     }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinEffectCloudEntity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinEffectCloudEntity.java
@@ -1,0 +1,30 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.custom;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import iskallia.vault.entity.entity.EffectCloudEntity;
+import iskallia.vault.init.ModEffects;
+import net.minecraft.world.effect.MobEffectInstance;
+import net.minecraft.world.entity.LivingEntity;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import xyz.iwolfking.woldsvaults.api.util.BleedSourceRegistry;
+
+@Mixin(value = EffectCloudEntity.class, remap = false)
+public abstract class MixinEffectCloudEntity {
+    /**
+     * Registers the cloud's owner as the Bleed source before the effect lands, so Bleed
+     * applied by effect-cloud gear modifiers awards kill credit.
+     */
+    @WrapOperation(
+        method = "tick",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/world/entity/LivingEntity;addEffect(Lnet/minecraft/world/effect/MobEffectInstance;)Z"),
+        remap = true
+    )
+    private boolean woldsvaults$registerBleedSource(LivingEntity target, MobEffectInstance effect, Operation<Boolean> original) {
+        if (effect.getEffect() == ModEffects.BLEED) {
+            BleedSourceRegistry.registerSource(target, ((EffectCloudEntity) (Object) this).getOwner());
+        }
+        return original.call(target, effect);
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesObjective.java
@@ -41,6 +41,7 @@ import net.minecraft.world.level.block.state.properties.DoubleBlockHalf;
 import net.minecraft.world.phys.AABB;
 import xyz.iwolfking.woldsvaults.api.util.ObjectiveHelper;
 import xyz.iwolfking.woldsvaults.api.util.SigilUtils;
+import xyz.iwolfking.woldsvaults.api.util.VaultMobUtils;
 import xyz.iwolfking.woldsvaults.objectives.hyper.HyperModifierPolicy;
 import xyz.iwolfking.woldsvaults.objectives.data.BrutalBossesRegistry;
 import xyz.iwolfking.woldsvaults.objectives.data.bosses.WoldBoss;
@@ -250,6 +251,7 @@ public class BrutalBossesObjective extends ObeliskObjective {
         LivingEntity entity = (LivingEntity) type.create(world);
 
         assert entity != null;
+        entity.addTag(VaultMobUtils.BRUTAL_BOSS_TAG);
         entity.setGlowingTag(true);
         if(entity instanceof WoldBoss) {
             entity.setCustomName(new TextComponent("Wold").withStyle(ChatFormatting.GOLD));

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -264,6 +264,7 @@
     "vaulthunters.custom.MixinDeckForgeRecipe",
     "vaulthunters.custom.MixinDeckModifierAdapter",
     "vaulthunters.custom.MixinDeckSocketAnvilRecipe",
+    "vaulthunters.custom.MixinEffectCloudEntity",
     "vaulthunters.custom.MixinEntityEvents",
     "vaulthunters.custom.MixinEtchingApplicationTableTileEntity",
     "vaulthunters.custom.MixinEtchingHelper",


### PR DESCRIPTION
Two related percent-damage fixes.

**Bleed kill credit and boss falloff** (88fb6501)
- Bleed ticks now damage through a source attributed to the applier (the PoisonOverrideEffect pattern: source registry, armor/magic-bypassing hurt inside shotgunAttack, ActiveFlags guards), so bleed kills award XP, player-kill loot, and objective credit instead of dying to generic magic.

**Concentrated Drain vs hyperbosses** (f2ce2f06)
- The concentrate_drain etching deals percent-current-health damage per effect drained, which scales with hyper health pools like the other percent sources already denied there (bleed is application-denied by HyperVaultEvents). Drain damage is now skipped on hyperbosses; effect stripping and buff conversion still work.

Behavior notes: bleed now respects invulnerability and hurt overrides (champion Immune phases can no longer be pierced by bleed; a player bleeding out can be totem-saved), and mobs retaliate against bleed ticks the same way they do against poison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)