### PR TITLE
Fix objective client sync against the_vault 3.21.6

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinObeliskObjectiveWaveSync.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinObeliskObjectiveWaveSync.java
@@ -1,0 +1,54 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.objective.ObeliskObjective;
+import iskallia.vault.core.world.storage.VirtualWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+/**
+ * the_vault 3.21.6's dirty-listener sync cannot see obelisk wave mutations: WAVES holds a
+ * plain Wave[] array, and only ICompound field values get dirty listeners attached, so
+ * activating a wave, spawning its mobs or counting a kill never re-syncs to clients — every
+ * obelisk counter (including the brutal-pillar counters of the subclassing
+ * BrutalBossesObjective) freezes at its initial state while the server plays on normally.
+ * Re-hash the wave state each server tick and mark WAVES dirty on change, mirroring what VH
+ * itself added to RuneBossObjective for its equally sync-invisible FIGHTS field.
+ */
+@Mixin(value = ObeliskObjective.class, remap = false)
+public abstract class MixinObeliskObjectiveWaveSync {
+    @Unique
+    private boolean woldsVaults$waveSyncInitialized;
+    @Unique
+    private long woldsVaults$lastWaveSyncState;
+
+    @Inject(method = "tickServer", at = @At("HEAD"))
+    private void woldsVaults$markWavesDirtyIfChanged(VirtualWorld world, Vault vault, CallbackInfo ci) {
+        ObeliskObjective self = (ObeliskObjective) (Object) this;
+        ObeliskObjective.Wave[] waves = self.get(ObeliskObjective.WAVES);
+        if (waves == null) {
+            return;
+        }
+        long state = -3750763034362895579L;
+        for (ObeliskObjective.Wave wave : waves) {
+            state = woldsVaults$mix(state, wave.has(ObeliskObjective.Wave.ACTIVE) ? 1L : 0L);
+            state = woldsVaults$mix(state, wave.getOr(ObeliskObjective.Wave.COUNT, 0));
+            state = woldsVaults$mix(state, wave.getOr(ObeliskObjective.Wave.TARGET, 0));
+            state = woldsVaults$mix(state, wave.get(ObeliskObjective.Wave.MOBS) == null ? 0L : wave.get(ObeliskObjective.Wave.MOBS).size());
+        }
+        if (this.woldsVaults$waveSyncInitialized && this.woldsVaults$lastWaveSyncState == state) {
+            return;
+        }
+        this.woldsVaults$waveSyncInitialized = true;
+        this.woldsVaults$lastWaveSyncState = state;
+        self.markDirty(ObeliskObjective.WAVES);
+    }
+
+    @Unique
+    private static long woldsVaults$mix(long hash, long value) {
+        return (hash ^ value) * 1099511628211L;
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/HyperVaultObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/HyperVaultObjective.java
@@ -266,6 +266,8 @@ public class HyperVaultObjective extends Objective {
      */
     private final List<Mob> speedClampQueue = new ArrayList<>();
     private int speedClampCount = 0;
+    private boolean fightsSyncStateInitialized;
+    private long lastFightsSyncState;
 
     protected HyperVaultObjective() {
         this.set(PHASE, Phase.ROLLING);
@@ -658,9 +660,28 @@ public class HyperVaultObjective extends Objective {
         this.cycleManager.tick();
         this.bossManager.tick();
         this.escalationManager.tick();
+        markFightsDirtyIfChanged();
         if (world.getGameTime() % PILLAR_PIN_PERIOD_TICKS == 0L) {
             pinPillarRuneDisplay(world);
         }
+    }
+
+    /**
+     * the_vault 3.21.6 replaced the per-tick objective resync with a dirty-listener tree, and
+     * FIGHTS sits behind an opaque DirectAdapter that tree cannot see into — without an
+     * explicit mark, clients keep the initial empty fight list forever (no hyperboss health
+     * bar, frozen fight visuals) while the server plays on normally. Re-hash the fight state
+     * once per tick and mark the field dirty on change, mirroring VH's own
+     * RuneBossObjective.markFightsDirtyIfChanged.
+     */
+    private void markFightsDirtyIfChanged() {
+        long syncState = this.get(FIGHTS).getClientSyncState();
+        if (this.fightsSyncStateInitialized && this.lastFightsSyncState == syncState) {
+            return;
+        }
+        this.fightsSyncStateInitialized = true;
+        this.lastFightsSyncState = syncState;
+        this.markDirty(FIGHTS);
     }
 
     /**

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -449,6 +449,7 @@
     "vaulthunters.fixes.MixinMonolithRenderer",
     "vaulthunters.fixes.MixinMultiJumpTrinket",
     "vaulthunters.fixes.MixinNecromancySkeletonEntity",
+    "vaulthunters.fixes.MixinObeliskObjectiveWaveSync",
     "vaulthunters.fixes.MixinOversizedSlotContainer",
     "vaulthunters.fixes.MixinPrestigePowerLevelMessage",
     "vaulthunters.fixes.MixinRebirthObjective",


### PR DESCRIPTION
the_vault 3.21.6 replaced the per-tick objective resync with a dirty-listener tree, which cannot see two kinds of objective state. This broke two displays while the server keeps playing the content normally:

- **Hyperboss health bar never appears**: HyperVaultObjective's FIGHTS field is an opaque DirectAdapter value, so fight mutations are invisible to the dirty tree and clients keep the initial empty fight list. Fixed by re-hashing the fight state each tick and marking the field dirty on change, mirroring the_vault's own RuneBossObjective.markFightsDirtyIfChanged.
- **Obelisk counters freeze** (including Brutal Pillars): ObeliskObjective's WAVES field holds a plain Wave[] array, and only ICompound field values get dirty listeners attached, so wave activation and kill counts never re-sync. Fixed with a hash-gated mixin on ObeliskObjective.tickServer that marks WAVES dirty on change — this also covers the_vault's own obelisk objectives, which have the same issue on 3.21.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)