### PR TITLE
Fix talent attribute modifiers persisting after unlearning

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinGearAttributeTalent.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinGearAttributeTalent.java
@@ -1,0 +1,38 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.gear.VaultGearHelper;
+import iskallia.vault.gear.attribute.VaultGearAttributeInstance;
+import iskallia.vault.skill.base.SkillContext;
+import iskallia.vault.skill.talent.type.GearAttributeTalent;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeInstance;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.util.stream.Stream;
+
+@Mixin(value = GearAttributeTalent.class, remap = false)
+public abstract class MixinGearAttributeTalent {
+
+    /**
+     * Strips this talent's vanilla attribute modifiers when it is unlearned.
+     * Once a talent is no longer present, getGearAttributes returns an empty stream, so the
+     * onRemoveModifiers call in onTick can never resolve the modifiers it is supposed to remove.
+     * Any vanilla-bound talent (Speed, Strength, Lunge, Medic) therefore keeps its transient
+     * modifier until relog, letting tier walks stack every traversed tier's buff at once.
+     */
+    @Inject(method = "onRemove", at = @At("HEAD"))
+    private void woldsVaults$removeAttributeModifiers(SkillContext context, CallbackInfo ci) {
+        GearAttributeTalent self = (GearAttributeTalent) (Object) this;
+        context.getSource().as(ServerPlayer.class).ifPresent(player ->
+            VaultGearHelper.getModifiers(self.getUuid(), Stream.of(VaultGearAttributeInstance.cast(self.getAttribute(), self.getValue())))
+                .forEach((attribute, modifier) -> {
+                    AttributeInstance instance = player.getAttribute(attribute);
+                    if (instance != null) {
+                        instance.removeModifier(modifier.getId());
+                    }
+                }));
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -438,6 +438,7 @@
     "vaulthunters.fixes.MixinEliteZombie",
     "vaulthunters.fixes.MixinEntityGroupsConfig",
     "vaulthunters.fixes.MixinFloatingItem",
+    "vaulthunters.fixes.MixinGearAttributeTalent",
     "vaulthunters.fixes.MixinImmortalityEffect",
     "vaulthunters.fixes.MixinIntegrationCurios",
     "vaulthunters.fixes.MixinJewelCraftingRecipe",


### PR DESCRIPTION
Fixes a seemingly nasty talent stacking bug that U33 seems to have caused due to swapping to a gear attribute stat system for talents. As far as I'm aware this is a real bug from my own testing and someone on discord, in the sense that unspeccing the talents doesn't actually do anything. For a technical description of what the fuck happened, see below:

U33 changed several talents (Speed, Speed II, Strength, Might II, Lunge, Medic) to tiered `gear_attribute` talents on vanilla-bound attributes (`movement_speed`, `attack_damage`, `attack_range`, `healing_effectiveness`). `GearAttributeTalent` applies these as **transient vanilla attribute modifiers**, re-added every tick while the tier child is present, with a deterministic UUID per tier id (`speed_1`, `speed_2`, ...).

The removal path is structurally dead: `onTick` calls `onRemoveModifiers(context)`, but `getGearAttributes(context)` is gated on `canApply()` (= `isUnlocked()`), so once a tier child is no longer present the stream is empty and nothing is ever removed. Nothing else in the mod removes these modifiers (verified by scanning the 3.21.6 jar for all `onRemoveModifiers` callers).

FYI, I know you don't love to patch vanilla bugs on the regular because ostensibly vanilla will fix it at some point, but this bricks all stat based talents on relog and forces you to unlearn and relearn all the flat stat talents every time you rejoin, which is annoying enough to warrant a fix now before vanilla. 