### PR TITLE
Fix Weighted Boots on fused trinkets

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/blocks/tiles/TrinketFusionForgeTileEntity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/blocks/tiles/TrinketFusionForgeTileEntity.java
@@ -33,6 +33,7 @@ import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
 import org.jetbrains.annotations.Nullable;
 import xyz.iwolfking.woldsvaults.blocks.containers.TrinketFusionContainer;
+import xyz.iwolfking.woldsvaults.effect.trinkets.SpeedLimitTrinketEffect;
 import xyz.iwolfking.woldsvaults.init.ModBlocks;
 import xyz.iwolfking.woldsvaults.init.ModFluids;
 import xyz.iwolfking.woldsvaults.items.CombinedTrinketItem;
@@ -125,6 +126,11 @@ public class TrinketFusionForgeTileEntity extends BlockEntity implements MenuPro
                 effects,
                 VaultUsesHelper.getUses(storedA) + VaultUsesHelper.getUses(storedB)
         );
+
+        int capPercent = Math.max(SpeedLimitTrinketEffect.getCapPercent(storedA), SpeedLimitTrinketEffect.getCapPercent(storedB));
+        if (capPercent > 0) {
+            SpeedLimitTrinketEffect.setCapPercent(this.result, capPercent);
+        }
 
         this.progress = 0;
         this.crafting = true;

--- a/src/main/java/xyz/iwolfking/woldsvaults/client/events/KeyInputEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/client/events/KeyInputEvents.java
@@ -77,7 +77,7 @@ public class KeyInputEvents {
             return;
         }
         ItemStack stack = hovered.getItem();
-        if (!(stack.getItem() instanceof TrinketItem) || !TrinketItem.isIdentified(stack) || !(TrinketItem.getTrinket(stack).orElse(null) instanceof SpeedLimitTrinketEffect)) {
+        if (!SpeedLimitTrinketEffect.hasBootsEffect(stack) || !TrinketItem.isIdentified(stack)) {
             return;
         }
         boolean creative = containerScreen instanceof CreativeModeInventoryScreen;

--- a/src/main/java/xyz/iwolfking/woldsvaults/client/events/TooltipEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/client/events/TooltipEvents.java
@@ -1,5 +1,7 @@
 package xyz.iwolfking.woldsvaults.client.events;
 
+import iskallia.vault.config.TrinketConfig;
+import iskallia.vault.gear.trinket.TrinketEffect;
 import iskallia.vault.item.gear.TrinketItem;
 import net.minecraft.ChatFormatting;
 import net.minecraft.network.chat.Component;
@@ -11,8 +13,11 @@ import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import xyz.iwolfking.woldsvaults.WoldsVaults;
 import xyz.iwolfking.woldsvaults.effect.trinkets.SpeedLimitTrinketEffect;
+import xyz.iwolfking.woldsvaults.items.CombinedTrinketItem;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 @Mod.EventBusSubscriber(modid = WoldsVaults.MOD_ID, bus = Mod.EventBusSubscriber.Bus.FORGE, value = Dist.CLIENT)
 public class TooltipEvents {
@@ -21,22 +26,57 @@ public class TooltipEvents {
     @SubscribeEvent
     public static void onItemTooltip(ItemTooltipEvent event) {
         ItemStack stack = event.getItemStack();
-        if (!(stack.getItem() instanceof TrinketItem) || !TrinketItem.isIdentified(stack) || !(TrinketItem.getTrinket(stack).orElse(null) instanceof SpeedLimitTrinketEffect)) {
+        if (!SpeedLimitTrinketEffect.hasBootsEffect(stack) || !TrinketItem.isIdentified(stack)) {
             return;
         }
         int capPercent = SpeedLimitTrinketEffect.getCapPercent(stack);
         Component line = new TextComponent("Current speed limit: " + (capPercent <= 0 ? "Uncapped" : capPercent + "%")).withStyle(ChatFormatting.GRAY);
         List<Component> tooltip = event.getToolTip();
-        for (int i = 1; i < tooltip.size(); i++) {
-            if (tooltip.get(i).getString().isEmpty()) {
-                tooltip.add(i, line);
-                return;
-            }
+        int insertAt = findInsertIndex(stack, tooltip);
+        if (insertAt >= 0) {
+            tooltip.add(insertAt, line);
+            return;
         }
         tooltip.add(line);
         if (!loggedInsertFallback) {
             loggedInsertFallback = true;
-            WoldsVaults.LOGGER.warn("Weighted Boots: could not find the expected blank tooltip line, appended the speed limit line at the end instead.");
+            WoldsVaults.LOGGER.warn("Weighted Boots: could not find the expected tooltip position, appended the speed limit line at the end instead.");
         }
+    }
+
+    private static int findInsertIndex(ItemStack stack, List<Component> tooltip) {
+        if (stack.getItem() instanceof CombinedTrinketItem) {
+            String bootsName = null;
+            Set<String> otherNames = new HashSet<>();
+            for (TrinketEffect<?> effect : CombinedTrinketItem.getTrinkets(stack)) {
+                TrinketConfig.Trinket cfg = effect.getTrinketConfig();
+                if (cfg == null) {
+                    continue;
+                }
+                if (effect instanceof SpeedLimitTrinketEffect) {
+                    bootsName = cfg.getName();
+                } else {
+                    otherNames.add(cfg.getName());
+                }
+            }
+            if (bootsName != null) {
+                for (int i = 1; i < tooltip.size(); i++) {
+                    if (!tooltip.get(i).getString().equals(bootsName)) {
+                        continue;
+                    }
+                    int insertAt = i + 1;
+                    while (insertAt < tooltip.size() && !tooltip.get(insertAt).getString().isEmpty() && !otherNames.contains(tooltip.get(insertAt).getString())) {
+                        insertAt++;
+                    }
+                    return insertAt;
+                }
+            }
+        }
+        for (int i = 1; i < tooltip.size(); i++) {
+            if (tooltip.get(i).getString().isEmpty()) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/effect/trinkets/SpeedLimitTrinketEffect.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/effect/trinkets/SpeedLimitTrinketEffect.java
@@ -1,10 +1,12 @@
 package xyz.iwolfking.woldsvaults.effect.trinkets;
 
 import iskallia.vault.gear.trinket.TrinketEffect;
+import iskallia.vault.item.gear.TrinketItem;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.Tag;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import xyz.iwolfking.woldsvaults.items.CombinedTrinketItem;
 
 public class SpeedLimitTrinketEffect extends TrinketEffect.Simple {
     public static final String SPEED_CAP_TAG = "woldsvaults:speed_cap";
@@ -12,6 +14,16 @@ public class SpeedLimitTrinketEffect extends TrinketEffect.Simple {
 
     public SpeedLimitTrinketEffect(ResourceLocation name) {
         super(name);
+    }
+
+    /**
+     * True if the stack carries this effect, either as a plain trinket or anywhere in a fused CombinedTrinketItem.
+     */
+    public static boolean hasBootsEffect(ItemStack stack) {
+        if (stack.getItem() instanceof CombinedTrinketItem) {
+            return CombinedTrinketItem.getTrinkets(stack).stream().anyMatch(effect -> effect instanceof SpeedLimitTrinketEffect);
+        }
+        return stack.getItem() instanceof TrinketItem && TrinketItem.getTrinket(stack).orElse(null) instanceof SpeedLimitTrinketEffect;
     }
 
     /**

--- a/src/main/java/xyz/iwolfking/woldsvaults/network/packets/ServerboundSetTrinketSpeedCapPacket.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/network/packets/ServerboundSetTrinketSpeedCapPacket.java
@@ -51,7 +51,7 @@ public class ServerboundSetTrinketSpeedCapPacket {
                 }
                 stack = menu.getSlot(packet.slotIndex).getItem();
             }
-            if (!(stack.getItem() instanceof TrinketItem) || !TrinketItem.isIdentified(stack) || !(TrinketItem.getTrinket(stack).orElse(null) instanceof SpeedLimitTrinketEffect)) {
+            if (!SpeedLimitTrinketEffect.hasBootsEffect(stack) || !TrinketItem.isIdentified(stack)) {
                 WoldsVaults.LOGGER.warn("Weighted Boots: speed cap packet from {} targets slot {} which does not hold identified Weighted Boots, ignoring.", player.getGameProfile().getName(), packet.slotIndex);
                 return;
             }


### PR DESCRIPTION
Weighted Boots stopped working when fused in the Trinket Fusion Forge. Two causes:

- The G-key config screen, tooltip line, and server-side cap write all resolved the trinket effect through `TrinketItem.getTrinket`, which returns only the first stored effect on a `CombinedTrinketItem` — so everything broke whenever the boots were the second-stored effect (and only worked by accident when they were first).
- `TrinketFusionForgeTileEntity.startCraft` builds the fused stack from effects and uses only, dropping the configured `woldsvaults:speed_cap` NBT from the input boots.

Changes:

- New `SpeedLimitTrinketEffect.hasBootsEffect(ItemStack)` checks all effects on `CombinedTrinketItem` stacks and falls back to `getTrinket` for plain trinkets; used by the keybind handler, tooltip event, and packet validation.
- The configured speed cap now carries through fusion (at most one input can be Weighted Boots, since same-effect fusion is blocked and combined trinkets cannot be re-fused).
- On fused tooltips the "Current speed limit" line inserts directly under the Weighted Boots description block instead of before the slot line.

The equipped-cap tick path needed no changes — it already sees fused boots through MixinTrinketHelper and reads the cap off the combined stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
