### PR TITLE
Fix doubled effects on fused trinkets

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/items/CombinedTrinketItem.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/items/CombinedTrinketItem.java
@@ -96,11 +96,23 @@ public class CombinedTrinketItem extends TrinketItem implements IManualModelLoad
                 .map(VaultGearAttributeInstance::getValue).collect(Collectors.toUnmodifiableList());
     }
 
+    /**
+     * Returns the stored effects that this item is responsible for driving itself, which is every
+     * effect except the first. {@link TrinketItem}'s curio lifecycle resolves a single effect
+     * through {@code TrinketItem.getTrinket}, which always yields the first stored effect, so the
+     * first one is already handled by the {@code super} call in each lifecycle method and must not
+     * be applied again here.
+     */
+    private static List<TrinketEffect<?>> getSupplementalTrinkets(ItemStack stack) {
+        List<TrinketEffect<?>> effects = getTrinkets(stack);
+        return effects.isEmpty() ? effects : effects.subList(1, effects.size());
+    }
+
     @Override
     public void curioTick(SlotContext ctx, ItemStack stack) {
         if (!isIdentified(stack)) return;
 
-        for (TrinketEffect<?> effect : getTrinkets(stack)) {
+        for (TrinketEffect<?> effect : getSupplementalTrinkets(stack)) {
             if (effect.getRegistryName() == null) continue;
 
             if (!ChallengeCurseHelper.isTrinketDisabled(
@@ -116,7 +128,7 @@ public class CombinedTrinketItem extends TrinketItem implements IManualModelLoad
 
     @Override
     public void onEquip(SlotContext ctx, ItemStack prev, ItemStack stack) {
-        for (TrinketEffect<?> effect : getTrinkets(stack)) {
+        for (TrinketEffect<?> effect : getSupplementalTrinkets(stack)) {
             effect.onEquip(ctx.entity(), stack);
         }
         super.onEquip(ctx, prev, stack);
@@ -125,7 +137,7 @@ public class CombinedTrinketItem extends TrinketItem implements IManualModelLoad
     @Override
     public void onUnequip(String identifier, int index, LivingEntity livingEntity, ItemStack stack) {
         super.onUnequip(identifier, index, livingEntity, stack);
-        getTrinkets(stack).forEach(trinketEffect -> {
+        getSupplementalTrinkets(stack).forEach(trinketEffect -> {
             trinketEffect.onUnEquip(livingEntity, stack);
         });
     }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinTrinketHelper.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinTrinketHelper.java
@@ -27,6 +27,7 @@ public abstract class MixinTrinketHelper {
             CombinedTrinketItem.getTrinkets(stack).forEach(trinketEffect -> {
                 addMatchingTrinkets(trinkets, stack, trinketEffect, trinketClass);
             });
+            return Optional.empty();
         }
         return original.call(stack);
     }


### PR DESCRIPTION
﻿Fused trinkets (`woldsvaults:combined_trinket`) apply their first stored effect twice.

## Cause

`MixinTrinketHelper` wraps the `TrinketItem.getTrinket` call inside `TrinketHelper.getTrinkets(Map, Class)`. For a `CombinedTrinketItem` it adds every stored effect via `addMatchingTrinkets`, then still returns the original `Optional` — so the base mod's `.ifPresent(trinket -> addMatchingTrinkets(...))` adds the first effect a second time. `TrinketItem.getTrinket` is `getFirstValue(TRINKET_EFFECT)`, and `AttributeGearData` keeps insertion order, so the duplicated effect is always the one from input slot A (the left-hand name on the card).

Every consumer that iterates the returned list then counts it twice:

- `AttributeSnapshotCalculator` sums `GearAttributeTrinket.getAttributes()` per entry via `floatSum()`, so gear-attribute trinkets get exactly double value. Confirmed against reports: Tenos' Necklace 25% -> 50% item quantity, Picture of a Lucky Goose 50% -> 100% item rarity, Swift Amulet 15% -> 30% dodge, Stone of Jordan +1 -> +2 ability levels.
- `Runner` applies Golden Burger's vault-XP multiplier once per entry, giving `(1+x)^2`.
- `LivingEntityEvents` rolls Immortal Seal's chance per entry, so 5% becomes roughly 9.75%.
- `ExplosionBlockPreventionTrinket` likewise gives Portable Cat a second roll.

`VanillaAttributeTrinket` effects (Phylactery, Giant's Heart, Crystal Ball, High Heels) are unaffected in practice — their modifiers use fixed UUIDs and are guarded by `hasModifier`, so applying them twice is idempotent. That is why only some pairs show the bug.

This also affects combined trinkets produced by `tickRoll`, not only forge-fused ones.

## Changes

- `MixinTrinketHelper` returns `Optional.empty()` for a `CombinedTrinketItem` after adding its effects, so the base mod does not re-add the first one. Other `TrinketItem.getTrinket` call sites (slot identifier, tooltips, fusion validation) are untouched.
- `CombinedTrinketItem` had the same defect in `curioTick`/`onEquip`/`onUnequip`: it drove every stored effect itself and then called `super`, which drives the first effect again. A `getSupplementalTrinkets` helper now returns effects 1..n and `super` keeps handling effect 0, preserving its uses/Royale/curse logic. Latent today since the effects using those hooks are idempotent, but the same defect.
