### PR TITLE
Prevent echoing and Fanged Strike proc fangs from compounding damage

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/EvokerFangsAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/EvokerFangsAbility.java
@@ -61,7 +61,7 @@ public class EvokerFangsAbility extends InstantManaAbility {
             double z = player.getZ() + Math.sin(angle) * dist;
             double y = player.getY();
 
-            CustomFangEntity fangs = new CustomFangEntity(level, x, y, z, player.getYRot(), player, damage, this.executeThreshold, 0, 0,false);
+            CustomFangEntity fangs = new CustomFangEntity(level, x, y, z, player.getYRot(), player, damage, this.executeThreshold, 0, 0,false, false);
             level.addFreshEntity(fangs);
         }
     }

--- a/src/main/java/xyz/iwolfking/woldsvaults/abilities/EvokerFangsMawAbility.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/abilities/EvokerFangsMawAbility.java
@@ -53,7 +53,7 @@ public class EvokerFangsMawAbility extends InstantManaAbility {
                         Vec3 perpendicular = new Vec3(-look.z, 0, look.x).scale(side * 0.5);
                         Vec3 finalPos = spawnPos.add(perpendicular);
 
-                        CustomFangEntity fangs = new CustomFangEntity(level, finalPos.x, finalPos.y, finalPos.z, player.getYRot(), player, finalDamage, heartFragmentChance, getEffectDuration(player), effectAmplifier, true);
+                        CustomFangEntity fangs = new CustomFangEntity(level, finalPos.x, finalPos.y, finalPos.z, player.getYRot(), player, finalDamage, heartFragmentChance, getEffectDuration(player), effectAmplifier, true, false);
                         level.addFreshEntity(fangs);
                     }
                 });

--- a/src/main/java/xyz/iwolfking/woldsvaults/effect/mobeffects/EchoingPotionEffect.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/effect/mobeffects/EchoingPotionEffect.java
@@ -28,7 +28,7 @@ public class EchoingPotionEffect extends MobEffect {
         if(affected.getEffect(ModEffects.ECHOING) instanceof EchoingEffectInstance echo
         && !(echo.getAttacker() != null && WoldEtchingHelper.hasEtching(echo.getAttacker(), ModEtchingGearAttributes.REVERBERATION))) {
             WoldActiveFlags.IS_AOE2_ATTACK.maybeRunWithFlag(echo.noCleave, () ->
-                WoldActiveFlags.IS_UNLUCKY_ATTACK.maybeRunWithFlag(echo.noLuckyhit, () ->
+                WoldActiveFlags.IS_UNLUCKY_ATTACK.runWithFlag(() ->
                     WoldActiveFlags.IS_ECHOING_ATTACKING.runWithFlag(() ->
                         DamageUtil.shotgunAttack(affected, e -> e.hurt(echo.source, echo.damage))
                     )

--- a/src/main/java/xyz/iwolfking/woldsvaults/entities/projectiles/CustomFangEntity.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/entities/projectiles/CustomFangEntity.java
@@ -33,16 +33,18 @@ public class CustomFangEntity extends EvokerFangs {
     private int effectDuration = 180;
     private int effectAmplifier = 0;
     private boolean isMaw = false;
+    private boolean isProcFang = false;
 
 
 
-    public CustomFangEntity(Level level, double x, double y, double z, float yRot, LivingEntity owner, float damage, float executeThreshold, int effectDuration, int effectAmplifier, boolean isMaw) {
+    public CustomFangEntity(Level level, double x, double y, double z, float yRot, LivingEntity owner, float damage, float executeThreshold, int effectDuration, int effectAmplifier, boolean isMaw, boolean isProcFang) {
         this(ModEntities.CUSTOM_FANGS, level);
         this.setPos(x, y, z);
         this.setYRot(yRot);
         this.customDamage = damage;
         this.executeThreshold = executeThreshold;
         this.isMaw = isMaw;
+        this.isProcFang = isProcFang;
         this.effectDuration = effectDuration;
         this.effectAmplifier = effectAmplifier;
         this.setOwner(owner);
@@ -123,10 +125,14 @@ public class CustomFangEntity extends EvokerFangs {
             }
         }
 
-        WoldActiveFlags.IS_FANG_ATTACKING.runWithFlag(() -> {
-            pTarget.invulnerableTime = 0;
-            pTarget.hurt(DamageSource.playerAttack(player), customDamage);
-        });
+        WoldActiveFlags.IS_UNLUCKY_ATTACK.maybeRunWithFlag(isProcFang, () ->
+            WoldActiveFlags.IS_PROC_FANG_ATTACKING.maybeRunWithFlag(isProcFang, () ->
+                WoldActiveFlags.IS_FANG_ATTACKING.runWithFlag(() -> {
+                    pTarget.invulnerableTime = 0;
+                    pTarget.hurt(DamageSource.playerAttack(player), customDamage);
+                })
+            )
+        );
 
         if (!isMaw) {
 
@@ -145,7 +151,13 @@ public class CustomFangEntity extends EvokerFangs {
 
                 serverLevel.playSound(null, pTarget.blockPosition(), SoundEvents.ZOMBIE_VILLAGER_CONVERTED, SoundSource.PLAYERS, 1.0F, 2.0F);
 
-                pTarget.hurt(DamageSource.playerAttack(player), Float.MAX_VALUE);
+                WoldActiveFlags.IS_UNLUCKY_ATTACK.runWithFlag(() ->
+                    WoldActiveFlags.IS_PROC_FANG_ATTACKING.runWithFlag(() ->
+                        WoldActiveFlags.IS_FANG_ATTACKING.runWithFlag(() ->
+                            pTarget.hurt(DamageSource.playerAttack(player), Float.MAX_VALUE)
+                        )
+                    )
+                );
 
                 spawnHeartFragment(pTarget);
 
@@ -175,6 +187,7 @@ public class CustomFangEntity extends EvokerFangs {
         nbt.putInt("EffectDuration", this.effectDuration);
         nbt.putInt("EffectAmplifier", this.effectAmplifier);
         nbt.putBoolean("IsMaw", this.isMaw);
+        nbt.putBoolean("IsProcFang", this.isProcFang);
     }
 
     @Override
@@ -185,5 +198,6 @@ public class CustomFangEntity extends EvokerFangs {
         this.effectDuration = nbt.getInt("EffectDuration");
         this.effectAmplifier = nbt.getInt("EffectAmplifier");
         this.isMaw = nbt.getBoolean("IsMaw");
+        this.isProcFang = nbt.getBoolean("IsProcFang");
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/LivingEntityEvents.java
@@ -330,7 +330,7 @@ public class LivingEntityEvents {
 
     @SubscribeEvent
     public static void cleavingDamage(LivingHurtEvent event) {
-        if(event.getSource().getEntity() instanceof Player player && WoldEventHelper.isNormalAttack()) {
+        if(event.getSource().getEntity() instanceof Player player && WoldEventHelper.isNormalAttack() && !WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
             if(player.getMainHandItem().getItem() instanceof VaultAxeItem) {
                 event.setAmount(event.getAmount() + WoldsAxeSpecializationTalent.applyCleavingDamageBonus(player, event.getEntityLiving()));
             }
@@ -395,6 +395,10 @@ public class LivingEntityEvents {
             return;
         }
 
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
+            return;
+        }
+
         if(event.getSource().isProjectile()) {
             return;
         }
@@ -427,6 +431,10 @@ public class LivingEntityEvents {
             return;
         }
 
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
+            return;
+        }
+
         if(event.getSource().isProjectile()) {
             return;
         }
@@ -451,6 +459,10 @@ public class LivingEntityEvents {
     public static void apScalingDamage(LivingHurtEvent event) {
         //Prevent an entity from being reaved more than once or applying to non-melee strikes.
         if(!WoldEventHelper.isNormalAttack()) {
+            return;
+        }
+
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
             return;
         }
 
@@ -508,6 +520,10 @@ public class LivingEntityEvents {
     public static void echoingHit(LivingHurtEvent event) {
 
         if(event.getSource().isProjectile()) {
+            return;
+        }
+
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
             return;
         }
 
@@ -603,7 +619,7 @@ public class LivingEntityEvents {
 //                                WoldsVaults.LOGGER.info("[WOLD'S VAULTS] Reverberated {} damage.", oDamage);
 
                                 WoldActiveFlags.IS_AOE2_ATTACK.maybeRunWithFlag(noCleave, () ->
-                                    WoldActiveFlags.IS_UNLUCKY_ATTACK.maybeRunWithFlag(noLuck, () ->
+                                    WoldActiveFlags.IS_UNLUCKY_ATTACK.runWithFlag(() ->
                                         WoldActiveFlags.IS_ECHOING_ATTACKING.runWithFlag(() ->
                                             DamageUtil.shotgunAttack(target, e -> e.hurt(oSource, oDamage))
                                         )
@@ -704,6 +720,10 @@ public class LivingEntityEvents {
     @SubscribeEvent(priority = EventPriority.HIGH)
     public static void onLivingHurt(LivingHurtEvent event) {
         if (!(event.getSource().getEntity() instanceof Player player)) {
+            return;
+        }
+
+        if (WoldActiveFlags.IS_FANG_ATTACKING.isSet()) {
             return;
         }
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/events/WoldActiveFlags.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/events/WoldActiveFlags.java
@@ -6,6 +6,7 @@ public enum WoldActiveFlags {
     IS_USING_SAFER_SPACE,
     IS_UNLUCKY_ATTACK,
     IS_FANG_ATTACKING,
+    IS_PROC_FANG_ATTACKING,
     IS_AOE2_ATTACK;
 
     private final ThreadLocal<Integer> activeReferences = ThreadLocal.withInitial(() -> 0);

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinGearAttributeEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinGearAttributeEvents.java
@@ -82,7 +82,8 @@ public class MixinGearAttributeEvents {
 
     /**
      * @author aida
-     * @reason to make the purist talent multiplicative
+     * @reason to make the purist talent multiplicative, and keep proc fangs from
+     * re-applying damage increases already contained in their stored damage
      */
     @Inject(method = "increaseDamageDealt",
             at = @At(value = "INVOKE",
@@ -90,12 +91,28 @@ public class MixinGearAttributeEvents {
                     shift = At.Shift.BEFORE),
             cancellable = true)
     private static void increaseDamageDealt(LivingHurtEvent event, CallbackInfo ci, @Local PlayerTalentsData talents, @Local float increasedDamage, @Local Player player) {
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
+            ci.cancel();
+            return;
+        }
+
         float puristMult = 1.0F;
         for(PuristTalent talent : talents.getTalents(player).getAll(PuristTalent.class, Skill::isUnlocked)) {
             puristMult += talent.getDamageIncrease() * (float)talent.getCount(player);
         }
         event.setAmount(event.getAmount() * (1.0F + increasedDamage) * puristMult);
         ci.cancel();
+    }
+
+    /**
+     * @author PoorMansPhysicist
+     * @reason keep proc fangs from re-applying fatal strike gear crits already
+     * contained in their stored damage
+     */
+    @Inject(method = "doFatalStrikeAttack", at = @At("HEAD"), cancellable = true)
+    private static void doFatalStrikeAttack(LivingHurtEvent event, CallbackInfo ci) {
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet())
+            ci.cancel();
     }
 
 

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinPlayerDamageHelper.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/custom/MixinPlayerDamageHelper.java
@@ -1,0 +1,24 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.custom;
+
+import iskallia.vault.util.damage.PlayerDamageHelper;
+import net.minecraftforge.event.entity.living.LivingHurtEvent;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import xyz.iwolfking.woldsvaults.events.WoldActiveFlags;
+
+@Mixin(value = PlayerDamageHelper.class, remap = false)
+public class MixinPlayerDamageHelper {
+    /**
+     * @author PoorMansPhysicist
+     * @reason keep proc fangs from re-applying player damage multipliers (Rampage etc.)
+     * already contained in their stored damage
+     */
+    @Inject(method = "onPlayerDamage", at = @At("HEAD"), cancellable = true)
+    private static void onPlayerDamage(LivingHurtEvent event, CallbackInfo ci) {
+        if(WoldActiveFlags.IS_PROC_FANG_ATTACKING.isSet()) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/talent/lucky_hit/FangedStrikeLuckyHitTalent.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/talent/lucky_hit/FangedStrikeLuckyHitTalent.java
@@ -55,7 +55,8 @@ public class FangedStrikeLuckyHitTalent extends LuckyHitTalent {
               0.0F,
               0,
               0,
-              false
+              false,
+              true
       );
 
       level.addFreshEntity(fang);

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -326,6 +326,7 @@
     "vaulthunters.custom.MixinObjectiveTemplates",
     "vaulthunters.custom.MixinOverviewContainerElement",
     "vaulthunters.custom.MixinPlayerBlackMarketData",
+    "vaulthunters.custom.MixinPlayerDamageHelper",
     "vaulthunters.custom.MixinPlayerGreedData",
     "vaulthunters.custom.MixinPlayerGreedTraderData",
     "vaulthunters.custom.MixinPlayerGreedTreeData",


### PR DESCRIPTION
Echoing hits could trigger lucky hits, and the fangs spawned by Fanged Strike re-applied damage modifiers (Rampage, damage increase, crits, execution bonuses) that were already folded into their inherited damage. Together these let echo/fang chains compound each other until hits reached the float limit.

Echo hits can no longer trigger lucky hits, and Fanged Strike fangs now deal exactly their inherited damage: no re-applied modifiers, no procs, no echo application. They still build on-hit stacks and effects as intended. Wall of Fangs and Hungry Maw are unchanged. Fang execute hits are also flagged so they can't proc or seed echoes.

Note: adds flag-gated cancels into the_vault's `PlayerDamageHelper.onPlayerDamage` and `GearAttributeEvents.doFatalStrikeAttack`; if those methods change in a future the_vault update, the mixins need re-checking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)