### PR TITLE
Gate Second Chance on percent health and add a scaling cooldown

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/SecondChanceHelper.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/SecondChanceHelper.java
@@ -1,0 +1,42 @@
+package xyz.iwolfking.woldsvaults.api.util;
+
+import net.minecraft.server.level.ServerPlayer;
+
+public class SecondChanceHelper {
+
+    private static final String LAST_ACTIVATION_TAG = "woldsvaults_second_chance_last_activation";
+    private static final float ACTIVATION_HEALTH_PERCENT = 0.65F;
+    private static final float MINIMUM_ACTIVATION_HEALTH = 13.5F;
+    private static final float REMAINDER_HEALTH_PERCENT = 0.05F;
+    private static final long COOLDOWN_TICKS = 60L;
+
+    /**
+     * Second Chance may only save a player who is above both 65% of their maximum health and 13.5
+     * absolute health, and whose previous activation is at least 3 seconds old. The percentage gate
+     * keeps it to genuine one shots on large health pools; the absolute gate keeps it from becoming
+     * an immortality loop once a player's maximum health has been ground down.
+     */
+    public static boolean canActivate(ServerPlayer player) {
+        float health = player.getHealth();
+        if (health < MINIMUM_ACTIVATION_HEALTH || health < player.getMaxHealth() * ACTIVATION_HEALTH_PERCENT) {
+            return false;
+        }
+        return player.level.getGameTime() - getLastActivation(player) >= COOLDOWN_TICKS;
+    }
+
+    /**
+     * The health a player is left on when Second Chance saves them, scaled to their maximum health
+     * so that the outcome is the same fraction of a health bar at every health pool size.
+     */
+    public static float getRemainderHealth(ServerPlayer player) {
+        return player.getMaxHealth() * REMAINDER_HEALTH_PERCENT;
+    }
+
+    public static void markActivated(ServerPlayer player) {
+        player.getPersistentData().putLong(LAST_ACTIVATION_TAG, player.level.getGameTime());
+    }
+
+    private static long getLastActivation(ServerPlayer player) {
+        return player.getPersistentData().getLong(LAST_ACTIVATION_TAG);
+    }
+}

--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/SecondChanceHelper.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/SecondChanceHelper.java
@@ -1,27 +1,35 @@
 package xyz.iwolfking.woldsvaults.api.util;
 
+import iskallia.vault.core.vault.Vault;
+import iskallia.vault.core.vault.VaultUtils;
+import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
+
+import java.util.UUID;
 
 public class SecondChanceHelper {
 
     private static final String LAST_ACTIVATION_TAG = "woldsvaults_second_chance_last_activation";
+    private static final String ACTIVATION_COUNT_TAG = "woldsvaults_second_chance_activations";
+    private static final String ACTIVE_RUN_TAG = "woldsvaults_second_chance_run";
     private static final float ACTIVATION_HEALTH_PERCENT = 0.65F;
     private static final float MINIMUM_ACTIVATION_HEALTH = 13.5F;
     private static final float REMAINDER_HEALTH_PERCENT = 0.05F;
-    private static final long COOLDOWN_TICKS = 60L;
+    private static final long BASE_COOLDOWN_TICKS = 80L;
+    private static final int MAX_COOLDOWN_DOUBLINGS = 40;
 
     /**
      * Second Chance may only save a player who is above both 65% of their maximum health and 13.5
-     * absolute health, and whose previous activation is at least 3 seconds old. The percentage gate
+     * absolute health, and whose cooldown from any earlier save has elapsed. The percentage gate
      * keeps it to genuine one shots on large health pools; the absolute gate keeps it from becoming
-     * an immortality loop once a player's maximum health has been ground down.
+     * an immortality loop on a small one.
      */
     public static boolean canActivate(ServerPlayer player) {
         float health = player.getHealth();
         if (health < MINIMUM_ACTIVATION_HEALTH || health < player.getMaxHealth() * ACTIVATION_HEALTH_PERCENT) {
             return false;
         }
-        return player.level.getGameTime() - getLastActivation(player) >= COOLDOWN_TICKS;
+        return player.level.getGameTime() - getLastActivation(player) >= getCooldownTicks(player);
     }
 
     /**
@@ -33,7 +41,42 @@ public class SecondChanceHelper {
     }
 
     public static void markActivated(ServerPlayer player) {
-        player.getPersistentData().putLong(LAST_ACTIVATION_TAG, player.level.getGameTime());
+        CompoundTag data = player.getPersistentData();
+        data.putInt(ACTIVATION_COUNT_TAG, getActivationCount(player) + 1);
+        data.putString(ACTIVE_RUN_TAG, getActiveRunId(player));
+        data.putLong(LAST_ACTIVATION_TAG, player.level.getGameTime());
+    }
+
+    /**
+     * Every save within a vault doubles the wait before the next one is available, starting at four
+     * seconds, so leaning on Second Chance repeatedly prices it out of the rest of the run.
+     */
+    private static long getCooldownTicks(ServerPlayer player) {
+        int activations = getActivationCount(player);
+        if (activations <= 0) {
+            return 0L;
+        }
+        return BASE_COOLDOWN_TICKS << Math.min(activations - 1, MAX_COOLDOWN_DOUBLINGS);
+    }
+
+    /**
+     * The escalation is scoped to a single vault run: a count recorded against any other vault, or
+     * recorded outside a vault entirely, reads as zero and starts the ladder over.
+     */
+    private static int getActivationCount(ServerPlayer player) {
+        String activeRun = getActiveRunId(player);
+        CompoundTag data = player.getPersistentData();
+        if (activeRun.isEmpty() || !activeRun.equals(data.getString(ACTIVE_RUN_TAG))) {
+            return 0;
+        }
+        return data.getInt(ACTIVATION_COUNT_TAG);
+    }
+
+    private static String getActiveRunId(ServerPlayer player) {
+        return VaultUtils.getVault(player.getLevel())
+                .map(vault -> vault.get(Vault.ID))
+                .map(UUID::toString)
+                .orElse("");
     }
 
     private static long getLastActivation(ServerPlayer player) {

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/secondchance/MixinSecondChanceEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/secondchance/MixinSecondChanceEvents.java
@@ -1,6 +1,5 @@
 package xyz.iwolfking.woldsvaults.mixins.secondchance;
 
-import iskallia.vault.core.vault.VaultUtils;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraftforge.event.entity.living.LivingDamageEvent;
 import org.infernalstudios.secondchanceforge.SecondChanceEvents;
@@ -8,7 +7,6 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-import xyz.iwolfking.woldsvaults.api.util.HealthReductionHelper;
 import xyz.iwolfking.woldsvaults.api.util.SecondChanceHelper;
 
 @Mixin(value = SecondChanceEvents.class, remap = false)
@@ -26,10 +24,6 @@ public class MixinSecondChanceEvents {
         if(event.getEntity() instanceof ServerPlayer player && event.getEntity().isAlive()) {
             event.setAmount(player.getHealth() - SecondChanceHelper.getRemainderHealth(player));
             SecondChanceHelper.markActivated(player);
-
-            if(VaultUtils.getVault(event.getEntity().getLevel()).isPresent()) {
-                HealthReductionHelper.reducePlayerMaxHealth(player);
-            }
         }
     }
 }

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/secondchance/MixinSecondChanceEvents.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/secondchance/MixinSecondChanceEvents.java
@@ -9,13 +9,27 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import xyz.iwolfking.woldsvaults.api.util.HealthReductionHelper;
+import xyz.iwolfking.woldsvaults.api.util.SecondChanceHelper;
 
 @Mixin(value = SecondChanceEvents.class, remap = false)
 public class MixinSecondChanceEvents {
+
+    @Inject(method = "onEntityDamage", at = @At("HEAD"), cancellable = true)
+    private void gateSecondChanceActivation(LivingDamageEvent event, CallbackInfo ci) {
+        if (event.getEntity() instanceof ServerPlayer player && !SecondChanceHelper.canActivate(player)) {
+            ci.cancel();
+        }
+    }
+
     @Inject(method = "onEntityDamage", at = @At(value = "INVOKE", target = "Lnet/minecraftforge/event/entity/living/LivingDamageEvent;setAmount(F)V", shift = At.Shift.AFTER))
-    private void reducePlayerHealthOnProc(LivingDamageEvent event, CallbackInfo ci) {
-        if(event.getEntity() instanceof ServerPlayer player && VaultUtils.getVault(event.getEntity().getLevel()).isPresent() && event.getEntity().isAlive()) {
-            HealthReductionHelper.reducePlayerMaxHealth(player);
+    private void onSecondChanceActivated(LivingDamageEvent event, CallbackInfo ci) {
+        if(event.getEntity() instanceof ServerPlayer player && event.getEntity().isAlive()) {
+            event.setAmount(player.getHealth() - SecondChanceHelper.getRemainderHealth(player));
+            SecondChanceHelper.markActivated(player);
+
+            if(VaultUtils.getVault(event.getEntity().getLevel()).isPresent()) {
+                HealthReductionHelper.reducePlayerMaxHealth(player);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes second chance behavior to be less annoying. Second chance will now only proc if a person is both above 13.5hp AND 65% of their max hp, instead of one or the other, and it has a 4 second cooldown after proccing. It also doesn't reduce max health anymore, but it's cooldown doubles every time you proc it, so the more you use it, the less you have it later. I didn't really like how easy it was to rely on this ability and how easily it procced when you had a lot of max hp, so i figured i'd reign in it's strength a little bit while keeping the idea that it really is only there to prevent you from getting one shot, nothing more. the max hp reduction was just a cause of anger amoung a lot of people i think since it sort of ruined vaults for people once they got down to basically no hp. 