### PR TITLE
Fix gear modifier rolls ignoring configured weights

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearModifierHelper.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearModifierHelper.java
@@ -2,6 +2,7 @@ package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
 
 import iskallia.vault.block.PlaceholderBlock;
 import iskallia.vault.config.gear.VaultGearTierConfig;
+import iskallia.vault.core.random.RandomSource;
 import iskallia.vault.core.util.WeightedList;
 import iskallia.vault.gear.VaultGearModifierHelper;
 import iskallia.vault.gear.attribute.VaultGearModifier;
@@ -10,15 +11,20 @@ import iskallia.vault.gear.attribute.talent.TalentLevelAttribute;
 import iskallia.vault.gear.comparator.VaultGearAttributeComparator;
 import iskallia.vault.gear.data.VaultGearData;
 import iskallia.vault.gear.modification.GearModification;
+import iskallia.vault.init.ModGearAttributes;
 import iskallia.vault.util.MiscUtils;
 import net.minecraft.util.Tuple;
 import net.minecraft.world.item.ItemStack;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Overwrite;
 import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
+import java.util.function.Predicate;
 
 @Mixin(value = VaultGearModifierHelper.class, remap = false, priority = 1500)
 public abstract class MixinVaultGearModifierHelper {
@@ -176,6 +182,59 @@ public abstract class MixinVaultGearModifierHelper {
         }
 
         return null;
+    }
+
+    /**
+     * @author PoorMansPhysicist
+     * @reason Draw from one weighted pool of every rollable tier the filter matches, so a tier's
+     * weight is relative to all other modifiers rather than only the other tiers of its own
+     * modifier.
+     */
+    @Overwrite
+    private static Optional<VaultGearModifierHelper.TierGroupOutcome> getRandomAvailableModGroupOutcome(Predicate<VaultGearTierConfig.ModifierTierGroup> filter, ItemStack stack, boolean anyGroup, Random random) {
+        return woldsVaults$getAvailableModGroupOutcomes(filter, stack, anyGroup).getRandom(random);
+    }
+
+    /**
+     * @author PoorMansPhysicist
+     * @reason Draw from one weighted pool of every rollable tier the filter matches, so a tier's
+     * weight is relative to all other modifiers rather than only the other tiers of its own
+     * modifier.
+     */
+    @Overwrite
+    private static Optional<VaultGearModifierHelper.TierGroupOutcome> getRandomAvailableModGroupOutcome(Predicate<VaultGearTierConfig.ModifierTierGroup> filter, ItemStack stack, boolean anyGroup, RandomSource random) {
+        return woldsVaults$getAvailableModGroupOutcomes(filter, stack, anyGroup).getRandom(random);
+    }
+
+    @Unique
+    private static WeightedList<VaultGearModifierHelper.TierGroupOutcome> woldsVaults$getAvailableModGroupOutcomes(Predicate<VaultGearTierConfig.ModifierTierGroup> filter, ItemStack stack, boolean anyGroup) {
+        WeightedList<VaultGearModifierHelper.TierGroupOutcome> outcomes = new WeightedList<>();
+        VaultGearTierConfig cfg = VaultGearTierConfig.getConfig(stack).orElse(null);
+        if (cfg == null) {
+            return outcomes;
+        }
+        VaultGearData data = VaultGearData.read(stack);
+        int itemLevel = data.getItemLevel();
+        Set<String> existingGroups = data.getExistingModifierGroups(VaultGearData.Type.ALL);
+        boolean generatePrefixes = data.getFirstValue(ModGearAttributes.PREFIXES).orElse(0) > data.getModifiers(VaultGearModifier.AffixType.PREFIX).size();
+        boolean generateSuffixes = data.getFirstValue(ModGearAttributes.SUFFIXES).orElse(0) > data.getModifiers(VaultGearModifier.AffixType.SUFFIX).size();
+        cfg.getAnyGroupsFulfilling(filter).forEach(tpl -> {
+            if (!anyGroup && !tpl.getA().isGenericGroup()) {
+                return;
+            }
+            if (existingGroups.contains(tpl.getB().getModifierGroup())) {
+                return;
+            }
+            VaultGearModifier.AffixType type = tpl.getA().getTargetAffixType();
+            if (type == VaultGearModifier.AffixType.PREFIX && !generatePrefixes) {
+                return;
+            }
+            if (type == VaultGearModifier.AffixType.SUFFIX && !generateSuffixes) {
+                return;
+            }
+            tpl.getB().getModifiersForLevel(itemLevel).forEach(tier -> outcomes.add(new VaultGearModifierHelper.TierGroupOutcome(tpl.getA(), tpl.getB(), tier), tier.getWeight()));
+        });
+        return outcomes;
     }
 
     @Shadow

--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearTierConfig.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinVaultGearTierConfig.java
@@ -1,0 +1,71 @@
+package xyz.iwolfking.woldsvaults.mixins.vaulthunters.fixes;
+
+import iskallia.vault.config.gear.VaultGearTierConfig;
+import iskallia.vault.core.util.WeightedList;
+import iskallia.vault.gear.attribute.VaultGearModifier;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Overwrite;
+import org.spongepowered.asm.mixin.Shadow;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+
+@Mixin(value = VaultGearTierConfig.class, remap = false, priority = 1500)
+public abstract class MixinVaultGearTierConfig {
+    @Shadow
+    @Final
+    private Map<VaultGearTierConfig.ModifierAffixTagGroup, VaultGearTierConfig.AttributeGroup> modifierGroup;
+
+    /**
+     * @author PoorMansPhysicist
+     * @reason Draw from one weighted pool of every rollable tier in the affix pool, so a tier's
+     * weight is relative to all other modifiers rather than only the other tiers of its own
+     * modifier.
+     */
+    @Overwrite
+    public Optional<VaultGearModifier<?>> getRandomModifier(VaultGearTierConfig.ModifierAffixTagGroup affixTagGroup, int level, Random random, Set<String> excludedModGroups) {
+        VaultGearTierConfig.AttributeGroup attributePool = this.modifierGroup.get(affixTagGroup);
+        if (attributePool == null || attributePool.isEmpty()) {
+            return Optional.empty();
+        }
+        WeightedList<VaultGearTierConfig.ModifierOutcome<?>> outcomes = new WeightedList<>();
+        attributePool.forEach(group -> {
+            if (!group.getModifierGroup().isEmpty() && excludedModGroups.contains(group.getModifierGroup())) {
+                return;
+            }
+            group.getModifiersForLevel(level).forEach(tier -> outcomes.add(new VaultGearTierConfig.ModifierOutcome<>(tier, group), tier.getWeight()));
+        });
+        return outcomes.getRandom(random).map(outcome -> outcome.makeModifier(random));
+    }
+
+    /**
+     * @author PoorMansPhysicist
+     * @reason Draw from one weighted pool of every rollable tier in the affix pool, applying the
+     * existing tag penalty to each tier weight rather than to a modifier's chance of being picked.
+     */
+    @Overwrite
+    public Optional<VaultGearModifier<?>> getRandomModifierWithExistingTagPenalty(VaultGearTierConfig.ModifierAffixTagGroup affixTagGroup, int level, Random random, Set<String> excludedModGroups, Set<String> existingTags) {
+        VaultGearTierConfig.AttributeGroup attributePool = this.modifierGroup.get(affixTagGroup);
+        if (attributePool == null || attributePool.isEmpty()) {
+            return Optional.empty();
+        }
+        WeightedList<VaultGearTierConfig.ModifierOutcome<?>> outcomes = new WeightedList<>();
+        attributePool.forEach(group -> {
+            if (!group.getModifierGroup().isEmpty() && excludedModGroups.contains(group.getModifierGroup())) {
+                return;
+            }
+            boolean hasPenalty = !Collections.disjoint(group.getTags(), existingTags);
+            group.getModifiersForLevel(level).forEach(tier -> {
+                double weight = hasPenalty ? tier.getWeight() * 0.25D : tier.getWeight();
+                if (weight > 0.0D) {
+                    outcomes.add(new VaultGearTierConfig.ModifierOutcome<>(tier, group), weight);
+                }
+            });
+        });
+        return outcomes.getRandom(random).map(outcome -> outcome.makeModifier(random));
+    }
+}

--- a/src/main/resources/woldsvaults.mixins.json
+++ b/src/main/resources/woldsvaults.mixins.json
@@ -471,6 +471,7 @@
     "vaulthunters.fixes.MixinVaultChestTileEntity",
     "vaulthunters.fixes.MixinVaultGearModifierHelper",
     "vaulthunters.fixes.MixinVaultGearRarity",
+    "vaulthunters.fixes.MixinVaultGearTierConfig",
     "vaulthunters.fixes.MixinVaultUtils",
     "vaulthunters.fixes.MixinVorpalSealCost",
     "vaulthunters.fixes.MixinWardrobeTileEntity",


### PR DESCRIPTION
the_vault 3.21.6 split modifier rolling into picking a modifier and then one of its tiers, but weighted only the tier step, so every modifier in an affix pool became equally likely regardless of the weights configured for it. Rolls again draw from a single weighted pool of every rollable tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
