### PR TITLE
Cap Daycare at one stack per vault

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinModifiers.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/mixins/vaulthunters/fixes/MixinModifiers.java
@@ -8,11 +8,13 @@ import iskallia.vault.core.vault.Modifiers;
 import iskallia.vault.core.vault.modifier.modifier.HunterModifier;
 import iskallia.vault.core.vault.modifier.spi.ModifierContext;
 import iskallia.vault.core.vault.modifier.spi.VaultModifier;
+import net.minecraft.resources.ResourceLocation;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import java.util.List;
@@ -20,6 +22,26 @@ import java.util.function.Consumer;
 
 @Mixin(value = Modifiers.class, remap = false)
 public abstract class MixinModifiers extends DataObject<Modifiers> {
+
+    private static final ResourceLocation DAYCARE_ID = VaultMod.id("daycare");
+    private static final int MAX_DAYCARE_STACKS = 1;
+
+    /**
+     * Caps Daycare at one stack per vault. Every modifier stack gets its own modifier context UUID,
+     * so the duplicate check in EntityAttributeModifier never sees the other stacks and both of
+     * Daycare's children apply once per stack. Two stacks therefore sum to -100% mob size, which
+     * leaves mobs invisible, and -100% mob damage. Zeroing the amount drops the whole group rather
+     * than its children, so the lower_damage child that Unchallenge Stack also uses is untouched.
+     */
+    @ModifyVariable(method = "addModifier(Liskallia/vault/core/vault/modifier/spi/VaultModifier;IZLiskallia/vault/core/random/RandomSource;Ljava/util/function/Consumer;)Liskallia/vault/core/vault/Modifiers;", at = @At("HEAD"), ordinal = 0, argsOnly = true)
+    private int limitDaycareToOneStack(int amount, VaultModifier<?> modifier, int ignored0, boolean ignored1, RandomSource ignored2, Consumer<ModifierContext> ignored3) {
+        if (!DAYCARE_ID.equals(modifier.getId())) {
+            return amount;
+        }
+
+        return ((Modifiers) (Object) this).hasModifier(DAYCARE_ID) ? 0 : Math.min(amount, MAX_DAYCARE_STACKS);
+    }
+
 //    @Shadow
 //    @Final
 //    protected static FieldKey<Modifiers.Entry.List> ENTRIES;


### PR DESCRIPTION
Two stacks of Daycare on the same vault made mobs invisible and harmless. This prevents more than one daycare stack from applying their effects, so mobs can't go to -100% size and damage. Kind of a bandaid fix, but it was ruining hyper vaults for people.