### PR TITLE
Scale brutal boss pillars and bosses with sigil difficulty

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/api/util/SigilUtils.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/api/util/SigilUtils.java
@@ -1,10 +1,15 @@
 package xyz.iwolfking.woldsvaults.api.util;
 
 import iskallia.vault.VaultMod;
+import iskallia.vault.config.sigil.SigilDefinitionsConfig;
 import iskallia.vault.core.vault.Modifiers;
 import iskallia.vault.core.vault.Vault;
+import iskallia.vault.init.ModConfigs;
 import net.minecraft.resources.ResourceLocation;
+import xyz.iwolfking.woldsvaults.WoldsVaults;
 
+import javax.annotation.Nullable;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class SigilUtils {
@@ -27,6 +32,27 @@ public class SigilUtils {
         }
 
 
+    }
+
+    /**
+     * The vault's final difficulty expressed as a multiplier: 1.0 for a sigil-less vault, plus
+     * every difficulty source stacked on top of it. Only the crystal's sigil contributes today
+     * (its value comes from {@code sigils/definitions.json}), so a +3.0 sigil yields 4.0 — the
+     * 400% a player sees. A sigil id with no definition contributes nothing and is logged.
+     */
+    public static float getDifficultyMultiplier(@Nullable String sigil) {
+        if(sigil == null) {
+            return 1.0F;
+        }
+
+        Optional<SigilDefinitionsConfig.SigilDefinition> definition = ModConfigs.SIGIL_DEFINITIONS.get(sigil.toLowerCase());
+
+        if(definition.isEmpty()) {
+            WoldsVaults.LOGGER.warn("Sigil '{}' has no entry in sigils/definitions.json, counting its difficulty as 0", sigil);
+            return 1.0F;
+        }
+
+        return 1.0F + definition.get().getDifficulty();
     }
 
     public static int getStackCountForSigil(String sigil) {

--- a/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesCrystalObjective.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/objectives/BrutalBossesCrystalObjective.java
@@ -22,6 +22,7 @@ import net.minecraft.network.chat.TextComponent;
 import net.minecraft.network.chat.TranslatableComponent;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.TooltipFlag;
+import xyz.iwolfking.woldsvaults.api.util.SigilUtils;
 import xyz.iwolfking.woldsvaults.init.ModCustomVaultObjectiveEntries;
 
 import javax.annotation.Nullable;
@@ -30,6 +31,8 @@ import java.util.Optional;
 import java.util.function.IntSupplier;
 
 public class BrutalBossesCrystalObjective extends WoldCrystalObjective {
+    private static final int MAX_OBELISKS = 10;
+
     protected IntRoll target;
     protected IntRoll wave;
     protected float objectiveProbability;
@@ -43,14 +46,22 @@ public class BrutalBossesCrystalObjective extends WoldCrystalObjective {
         this.objectiveProbability = objectiveProbability;
     }
 
-    //TODO: Add Sigil Support
+    /**
+     * Sigils scale the fight, not just its modifiers: the vault's final difficulty multiplier
+     * (1 + every difficulty source, so a +3.0 sigil reads as 400%) is square-rooted and applied
+     * to both the pillar count and each pillar's boss count, rounded down — 400% turns 4 pillars
+     * of 2 bosses into 8 pillars of 4. Pillars are capped at {@link #MAX_OBELISKS}; boss counts
+     * are not. The challenge stacks a sigil grants are added separately in
+     * {@link xyz.iwolfking.woldsvaults.api.util.SigilUtils#addStacksFromSigil}.
+     */
     @Override
     public void configure(Vault vault, RandomSource random, @Nullable String sigil) {
         int level = vault.get(Vault.LEVEL).get();
+        double difficultyScale = Math.sqrt(SigilUtils.getDifficultyMultiplier(sigil));
         vault.ifPresent(Vault.OBJECTIVES, objectives -> {
-            IntSupplier limitedWave = () -> random.nextInt(3) + 1;
+            IntSupplier limitedWave = () -> (int) ((random.nextInt(3) + 1) * difficultyScale);
 
-            int obelisks = random.nextInt(3) + 3;
+            int obelisks = Math.min((int) ((random.nextInt(3) + 3) * difficultyScale), MAX_OBELISKS);
 
             objectives.add(BrutalBossesObjective.of(obelisks, limitedWave, this.objectiveProbability)
                     .add(AwardCrateObjective.ofConfig(VaultCrateBlock.Type.valueOf("BRUTAL_BOSSES"), "brutal_bosses", level, true))


### PR DESCRIPTION
Sigils currently only add challenge stacks to a brutal boss vault. This makes them scale the number of bosses and pillars also.

Pillars are capped at 10, boss counts are uncapped, and the challenge stacks sigils already grant are unchanged.

Resulting spread from the existing base rolls of 3-5 pillars x 1-3 bosses:

| sigil | difficulty | scale | pillars | bosses/pillar |
|---|---|---|---|---|
| none | 100% | 1.000 | 3-5 | 1-3 |
| adept | 150% | 1.225 | 3-6 | 1-3 |
| expert | 200% | 1.414 | 4-7 | 1-4 |
| master | 250% | 1.581 | 4-7 | 1-4 |
| veteran | 400% | 2.000 | 6-10 | 2-6 |
| legend | 600% | 2.449 | 7-10 | 2-7 |

Playtested on a live instance: pillar and boss counts scale as expected and the objective HUD renders without conflicts.
