### PR TITLE
prevent ItemStack.EMPTY modification

### DIFF
--- a/src/main/java/xyz/iwolfking/woldsvaults/client/invhud/LightmanWalletHudModule.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/client/invhud/LightmanWalletHudModule.java
@@ -58,7 +58,8 @@ public class LightmanWalletHudModule extends AbstractHudModule<ModuleRenderConte
 
         LightmanWalletHudOptions opts = this.option.getValue();
         ItemStack wallet = LightmansCurrency.getWalletStack(player);
-        CoinValue walletValue = MoneyUtil.getCoinValue(WalletItem.getWalletInventory(wallet));
+        List<ItemStack> walletInv = wallet.isEmpty() ? List.of() : WalletItem.getWalletInventory(wallet);
+        CoinValue walletValue = MoneyUtil.getCoinValue(walletInv);
 
         if (context.isEditing() && wallet.isEmpty()) {
             wallet = new ItemStack(ModItems.WALLET_COPPER.get());
@@ -288,7 +289,8 @@ public class LightmanWalletHudModule extends AbstractHudModule<ModuleRenderConte
         int gapCount = 0;
         if (player != null) {
             ItemStack wallet = LightmansCurrency.getWalletStack(player);
-            CoinValue walletValue = MoneyUtil.getCoinValue(WalletItem.getWalletInventory(wallet));
+            List<ItemStack> walletInv = wallet.isEmpty() ? List.of() : WalletItem.getWalletInventory(wallet);
+            CoinValue walletValue = MoneyUtil.getCoinValue(walletInv);
 
             if (context.isEditing() && wallet.isEmpty()) {
                 ArrayList<ItemStack> coins = new ArrayList<>();

--- a/src/main/java/xyz/iwolfking/woldsvaults/integration/occultism/impl/VaultCrystalRitual.java
+++ b/src/main/java/xyz/iwolfking/woldsvaults/integration/occultism/impl/VaultCrystalRitual.java
@@ -20,6 +20,10 @@ public class VaultCrystalRitual {
 
     public static ItemStack invokeRitual(ResourceLocation type, ItemStack crystalStack) {
         ItemStack output = crystalStack.copy();
+        if (output == ItemStack.EMPTY) { // do not modify the shared empty stack (idk how we get here)
+//            WoldsVaults.LOGGER.error("ItemStack.EMPTY for {} ritual", type);
+            return output;
+        }
 
         CrystalData.run(output, data -> {
             if (type.equals(EXTENDED)) {


### PR DESCRIPTION
idk why the ritual gets called with empty itemstack as the crystal stack

the ritual works fine if we just don't apply changes to it (but ofc it's not a proper fix)